### PR TITLE
Update zeebe-bpmn-moddle for ad-hoc sub-process support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "^9.12.0",
         "eslint-plugin-bpmn-io": "^2.0.2",
         "mocha": "^11.0.0",
-        "zeebe-bpmn-moddle": "^1.1.0"
+        "zeebe-bpmn-moddle": "^1.9.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4844,10 +4844,11 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg==",
+      "dev": true,
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -8335,9 +8336,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "eslint": "^9.12.0",
     "eslint-plugin-bpmn-io": "^2.0.2",
     "mocha": "^11.0.0",
-    "zeebe-bpmn-moddle": "^1.1.0"
+    "zeebe-bpmn-moddle": "^1.9.0"
   }
 }

--- a/test/cliSpec.js
+++ b/test/cliSpec.js
@@ -30,17 +30,20 @@ describe('cli', function() {
 
 
     test('add-item');
+
+
+    test('ad-hoc-sub-process', 'add-item');
   });
 });
 
-function test(testName, element = 'ServiceTask', only = false) {
+function test(testName, templateName = testName, element = 'ServiceTask', only = false) {
   const fn = only ? it.only : it;
 
   fn(`should work for: ${testName}`, async function() {
 
     // given
     const diagram = `test/fixtures/diagrams/${testName}.bpmn`;
-    const template = `test/fixtures/templates/${testName}.json`;
+    const template = `test/fixtures/templates/${templateName}.json`;
     const expected = await fs.readFile(`test/fixtures/diagrams/${testName}_expected.bpmn`, 'utf8');
 
     // when

--- a/test/fixtures/diagrams/ad-hoc-sub-process.bpmn
+++ b/test/fixtures/diagrams/ad-hoc-sub-process.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_040od8p" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1o69a6i" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a6hwox</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a6hwox" sourceRef="StartEvent_1" targetRef="ServiceTask" />
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>Flow_12dwv5d</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12dwv5d" sourceRef="Ad_Hoc_Sub_Process" targetRef="EndEvent" />
+    <bpmn:sequenceFlow id="Flow_1hdpex0" sourceRef="ServiceTask" targetRef="Ad_Hoc_Sub_Process" />
+    <bpmn:serviceTask id="ServiceTask">
+      <bpmn:incoming>Flow_1a6hwox</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hdpex0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:adHocSubProcess id="Ad_Hoc_Sub_Process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;Task_A&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hdpex0</bpmn:incoming>
+      <bpmn:outgoing>Flow_12dwv5d</bpmn:outgoing>
+      <bpmn:task id="Task_A" name="Task A" />
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=someVariable = "yes"</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1o69a6i">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0coo68a_di" bpmnElement="EndEvent">
+        <dc:Bounds x="852" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_132l89a_di" bpmnElement="ServiceTask">
+        <dc:Bounds x="280" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02uwkef_di" bpmnElement="Ad_Hoc_Sub_Process" isExpanded="true">
+        <dc:Bounds x="450" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uuqux3_di" bpmnElement="Task_A">
+        <dc:Bounds x="570" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1a6hwox_di" bpmnElement="Flow_1a6hwox">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="280" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12dwv5d_di" bpmnElement="Flow_12dwv5d">
+        <di:waypoint x="800" y="180" />
+        <di:waypoint x="852" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hdpex0_di" bpmnElement="Flow_1hdpex0">
+        <di:waypoint x="380" y="180" />
+        <di:waypoint x="450" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/diagrams/ad-hoc-sub-process_expected.bpmn
+++ b/test/fixtures/diagrams/ad-hoc-sub-process_expected.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_040od8p" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1o69a6i" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a6hwox</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a6hwox" sourceRef="StartEvent_1" targetRef="ServiceTask" />
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>Flow_12dwv5d</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12dwv5d" sourceRef="Ad_Hoc_Sub_Process" targetRef="EndEvent" />
+    <bpmn:sequenceFlow id="Flow_1hdpex0" sourceRef="ServiceTask" targetRef="Ad_Hoc_Sub_Process" />
+    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="05d1c06a-b65d-428c-8ca0-10c14b3fb0ee" zeebe:modelerTemplateVersion="3">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:aws-dynamodb:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="itemOperation" target="input.operationGroup" />
+          <zeebe:input source="addItem" target="input.itemOperation" />
+          <zeebe:input source="tableName" target="input.tableName" />
+          <zeebe:input source="={&#34;id&#34;:&#34;value&#34;}" target="input.item" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a6hwox</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hdpex0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:adHocSubProcess id="Ad_Hoc_Sub_Process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;Task_A&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hdpex0</bpmn:incoming>
+      <bpmn:outgoing>Flow_12dwv5d</bpmn:outgoing>
+      <bpmn:task id="Task_A" name="Task A" />
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=someVariable = "yes"</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1o69a6i">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0coo68a_di" bpmnElement="EndEvent">
+        <dc:Bounds x="852" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_132l89a_di" bpmnElement="ServiceTask">
+        <dc:Bounds x="280" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02uwkef_di" bpmnElement="Ad_Hoc_Sub_Process" isExpanded="true">
+        <dc:Bounds x="450" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uuqux3_di" bpmnElement="Task_A">
+        <dc:Bounds x="570" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1a6hwox_di" bpmnElement="Flow_1a6hwox">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="280" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12dwv5d_di" bpmnElement="Flow_12dwv5d">
+        <di:waypoint x="800" y="180" />
+        <di:waypoint x="852" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hdpex0_di" bpmnElement="Flow_1hdpex0">
+        <di:waypoint x="380" y="180" />
+        <di:waypoint x="450" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

When applying a template to a process containing an ad-hoc sub-process (can be any task within the diagram, does not need to be within or connected to the ad-hoc sub-process), the resulting BPMN is missing the `zeebe:adHoc` extension element as shown below:

![image](https://github.com/user-attachments/assets/6c86104c-a097-4439-9f2d-824ebd3c96f7)

This PR adds a test to verify the extension element is still present after applying the template and updates the `zeebe-bpmn-moddle` library to the latest version. Without the update, the test fails like in the screenshot above.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
