### PR TITLE
feat: add `query` and `set` subcommands for programmatic field access

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,46 +5,140 @@ import { parseArgs } from 'node:util';
 import { readFile, writeFile } from 'node:fs/promises';
 
 import {
-  applyTemplate
+  applyTemplate,
+  queryFields,
+  setFields
 } from '../dist/index.js';
 
-run();
+const SUBCOMMANDS = [ 'apply', 'query', 'set' ];
+
+run().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});
 
 async function run() {
 
+  // Detect subcommand: first non-flag argument
+  const subcommand = detectSubcommand();
+  const args = subcommand.detected
+    ? process.argv.slice(3)
+    : process.argv.slice(2);
+
+  switch (subcommand.name) {
+    case 'apply': return runApply(args);
+    case 'query': return runQuery(args);
+    case 'set': return runSet(args);
+    default:
+      console.error(
+        `Unknown subcommand "${subcommand.name}". Use "apply", "query", or "set".`
+      );
+      process.exit(1);
+  }
+}
+
+function detectSubcommand() {
+  const arg = process.argv[2];
+
+  // No arguments or starts with -- => default to 'apply' (backward compat)
+  if (!arg || arg.startsWith('--')) {
+    return { name: 'apply', detected: false };
+  }
+
+  // Only consume as subcommand if it's a known command,
+  // otherwise fall back to 'apply' (backward compat)
+  if (SUBCOMMANDS.includes(arg)) {
+    return { name: arg, detected: true };
+  }
+
+  return { name: 'apply', detected: false };
+}
+
+async function runApply(args) {
+
   const options = {
-    diagram: {
-      type: 'string'
-    },
-    template: {
-      type: 'string'
-    },
-    element: {
-      type: 'string'
-    },
-    output: {
-      type: 'string',
-      default: '-'
-    }
+    diagram: { type: 'string' },
+    template: { type: 'string' },
+    element: { type: 'string' },
+    output: { type: 'string', default: '-' }
   };
 
-  const { values } = parseArgs({ options });
+  const { values: opts } = parseArgs({ args, options });
 
-  for (const option in options) {
-    if (!values[option]) {
-      throw new Error(`Missing option "${option}"`);
+  requireOptions(opts, [ 'diagram', 'template', 'element' ]);
+
+  const diagram = await readFile(opts.diagram, 'utf8');
+  const template = await readFile(opts.template, 'utf8');
+
+  const xml = await applyTemplate(diagram, template, opts.element);
+
+  await output(xml, opts.output);
+}
+
+async function runQuery(args) {
+
+  const options = {
+    diagram: { type: 'string' },
+    template: { type: 'string' },
+    element: { type: 'string' }
+  };
+
+  const { values: opts } = parseArgs({ args, options });
+
+  requireOptions(opts, [ 'diagram', 'template', 'element' ]);
+
+  const diagram = await readFile(opts.diagram, 'utf8');
+  const template = await readFile(opts.template, 'utf8');
+
+  const result = await queryFields(diagram, template, opts.element);
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function runSet(args) {
+
+  const options = {
+    diagram: { type: 'string' },
+    template: { type: 'string' },
+    element: { type: 'string' },
+    values: { type: 'string' },
+    output: { type: 'string', default: '-' }
+  };
+
+  const { values: opts } = parseArgs({ args, options });
+
+  requireOptions(opts, [ 'diagram', 'template', 'element', 'values' ]);
+
+  const diagram = await readFile(opts.diagram, 'utf8');
+  const template = await readFile(opts.template, 'utf8');
+  const fieldValues = parseValues(opts.values);
+
+  const xml = await setFields(diagram, template, opts.element, fieldValues);
+
+  await output(xml, opts.output);
+}
+
+function requireOptions(opts, required) {
+  for (const name of required) {
+    if (opts[name] === undefined) {
+      console.error(`Missing required option "--${name}"`);
+      process.exit(1);
     }
   }
+}
 
-  const diagram = await readFile(values.diagram, 'utf8');
-  const template = await readFile(values.template, 'utf8');
-
-  const xml = await applyTemplate(diagram, template, values.element);
-
-  if (values.output === '-') {
-    console.log(xml);
-    return;
+function parseValues(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Invalid JSON in --values: ${ e.message }`);
   }
+}
 
-  await writeFile(values.output, xml);
+async function output(content, dest) {
+  if (!dest || dest === '-') {
+    console.log(content);
+  } else {
+    await writeFile(dest, content);
+  }
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,10 +7,125 @@ import { readFile, writeFile } from 'node:fs/promises';
 import {
   applyTemplate,
   queryFields,
-  setFields
+  setFields,
+  resolveTemplatePath,
+  resolveTemplateId,
+  listTemplates,
+  downloadTemplate
 } from '../dist/index.js';
 
-const SUBCOMMANDS = [ 'apply', 'query', 'set' ];
+const SUBCOMMANDS = [ 'apply', 'query', 'set', 'list', 'download' ];
+
+const HELP = {
+  root: `
+Usage: element-templates-cli [subcommand] [options]
+
+Subcommands:
+  apply      Apply an element template to a BPMN element (default)
+  query      Query visible fields of an element template as JSON
+  set        Set field values on a BPMN element via an element template
+  list       List available templates in local search paths
+  download   Download and cache templates from a remote JSON file
+
+Run \`element-templates-cli <subcommand> --help\` for subcommand details.
+`.trim(),
+
+  apply: `
+Usage: element-templates-cli [apply] [options]
+
+Apply an element template to a BPMN element.
+
+Template source (exactly one required):
+  --template-path, --tp <path>   Path to an element template JSON file
+  --template-id,   --ti <id>     Template ID (e.g. io.camunda.connectors.HttpJson.v2);
+                                 resolved via Desktop Modeler lookup paths and cached
+  --template           <path>    Deprecated alias for --template-path
+
+Options:
+  --diagram   <path>   Path to the BPMN diagram file (required)
+  --element   <id>     ID of the BPMN element to apply the template to (required)
+  --output    <path>   Output path for the modified diagram; use "-" for stdout (default: "-")
+  --help               Show this help message
+`.trim(),
+
+  query: `
+Usage: element-templates-cli query [options]
+
+Query the currently visible fields of an element template applied to a BPMN
+element. Returns a JSON object grouped by section, where each field includes:
+  type, value, choices (Dropdown), feel, constraints, description
+
+Hidden fields (condition not met) are excluded. Ungrouped fields appear under "General".
+
+Template source (exactly one required):
+  --template-path, --tp <path>   Path to an element template JSON file
+  --template-id,   --ti <id>     Template ID (e.g. io.camunda.connectors.HttpJson.v2)
+  --template           <path>    Deprecated alias for --template-path
+
+Options:
+  --diagram   <path>   Path to the BPMN diagram file (required)
+  --element   <id>     ID of the BPMN element to query (required)
+  --help               Show this help message
+`.trim(),
+
+  set: `
+Usage: element-templates-cli set [options]
+
+Set field values on a BPMN element via an element template. Supports cascading
+condition re-evaluation so newly-visible fields can be set in the same call.
+
+Field keys in --values use the field label (e.g. "Label"). Use "Section.Label"
+to disambiguate fields with the same label in different sections. Duplicate
+labels within a section are suffixed with "(N)" (e.g. "Label (2)").
+
+Constraints (notEmpty, pattern, minLength, maxLength) are enforced before applying.
+
+Template source (exactly one required):
+  --template-path, --tp <path>   Path to an element template JSON file
+  --template-id,   --ti <id>     Template ID (e.g. io.camunda.connectors.HttpJson.v2)
+  --template           <path>    Deprecated alias for --template-path
+
+Options:
+  --diagram   <path>     Path to the BPMN diagram file (required)
+  --element   <id>       ID of the BPMN element to modify (required)
+  --values    <json>     JSON object mapping field labels to values (required)
+                         Example: --values '{"Task Name": "my-task", "Retries": "3"}'
+  --output    <path>     Output path for the modified diagram; use "-" for stdout (default: "-")
+  --help                 Show this help message
+`.trim(),
+
+  list: `
+Usage: element-templates-cli list [options]
+
+List templates available in local search paths (Desktop Modeler user data dir
+and the CLI cache). When --id is given, all cached versions of that template
+are shown instead.
+
+Options:
+  --id    <id>   Show all cached versions of a specific template ID
+  --help         Show this help message
+`.trim(),
+
+  download: `
+Usage: element-templates-cli download [options]
+
+Download a template from the Camunda marketplace index and save it to the local
+CLI cache so it is available to --template-id lookups.
+
+Options:
+  --id        <id>       Template ID to download (required)
+  --version   <version>  Specific version to download (default: latest)
+  --help                 Show this help message
+`.trim()
+};
+
+const TEMPLATE_OPTIONS = {
+  'template-path': { type: 'string' },
+  'tp': { type: 'string' },
+  'template-id': { type: 'string' },
+  'ti': { type: 'string' },
+  'template': { type: 'string' }
+};
 
 run().catch(err => {
   console.error(err.message);
@@ -25,15 +140,22 @@ async function run() {
     ? process.argv.slice(3)
     : process.argv.slice(2);
 
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(subcommand.detected ? HELP[subcommand.name] : HELP.root);
+    return;
+  }
+
   switch (subcommand.name) {
-    case 'apply': return runApply(args);
-    case 'query': return runQuery(args);
-    case 'set': return runSet(args);
-    default:
-      console.error(
-        `Unknown subcommand "${subcommand.name}". Use "apply", "query", or "set".`
-      );
-      process.exit(1);
+  case 'apply': return runApply(args);
+  case 'query': return runQuery(args);
+  case 'set': return runSet(args);
+  case 'list': return runList(args);
+  case 'download': return runDownload(args);
+  default:
+    console.error(
+      `Unknown subcommand "${subcommand.name}". Use "apply", "query", "set", "list", or "download".`
+    );
+    process.exit(1);
   }
 }
 
@@ -58,17 +180,17 @@ async function runApply(args) {
 
   const options = {
     diagram: { type: 'string' },
-    template: { type: 'string' },
     element: { type: 'string' },
-    output: { type: 'string', default: '-' }
+    output: { type: 'string', default: '-' },
+    ...TEMPLATE_OPTIONS
   };
 
-  const { values: opts } = parseArgs({ args, options });
+  const { values: opts } = parseArgsOrHelp(args, options, 'apply');
 
-  requireOptions(opts, [ 'diagram', 'template', 'element' ]);
+  requireOptions(opts, [ 'diagram', 'element' ]);
 
   const diagram = await readFile(opts.diagram, 'utf8');
-  const template = await readFile(opts.template, 'utf8');
+  const template = await resolveTemplate(opts);
 
   const xml = await applyTemplate(diagram, template, opts.element);
 
@@ -79,16 +201,16 @@ async function runQuery(args) {
 
   const options = {
     diagram: { type: 'string' },
-    template: { type: 'string' },
-    element: { type: 'string' }
+    element: { type: 'string' },
+    ...TEMPLATE_OPTIONS
   };
 
-  const { values: opts } = parseArgs({ args, options });
+  const { values: opts } = parseArgsOrHelp(args, options, 'query');
 
-  requireOptions(opts, [ 'diagram', 'template', 'element' ]);
+  requireOptions(opts, [ 'diagram', 'element' ]);
 
   const diagram = await readFile(opts.diagram, 'utf8');
-  const template = await readFile(opts.template, 'utf8');
+  const template = await resolveTemplate(opts);
 
   const result = await queryFields(diagram, template, opts.element);
 
@@ -99,18 +221,18 @@ async function runSet(args) {
 
   const options = {
     diagram: { type: 'string' },
-    template: { type: 'string' },
     element: { type: 'string' },
     values: { type: 'string' },
-    output: { type: 'string', default: '-' }
+    output: { type: 'string', default: '-' },
+    ...TEMPLATE_OPTIONS
   };
 
-  const { values: opts } = parseArgs({ args, options });
+  const { values: opts } = parseArgsOrHelp(args, options, 'set');
 
-  requireOptions(opts, [ 'diagram', 'template', 'element', 'values' ]);
+  requireOptions(opts, [ 'diagram', 'element', 'values' ]);
 
   const diagram = await readFile(opts.diagram, 'utf8');
-  const template = await readFile(opts.template, 'utf8');
+  const template = await resolveTemplate(opts);
   const fieldValues = parseValues(opts.values);
 
   const xml = await setFields(diagram, template, opts.element, fieldValues);
@@ -118,12 +240,102 @@ async function runSet(args) {
   await output(xml, opts.output);
 }
 
+async function runList(args) {
+
+  const options = {
+    id: { type: 'string' }
+  };
+
+  const { values: opts } = parseArgsOrHelp(args, options, 'list');
+
+  const entries = await listTemplates();
+
+  if (opts.id) {
+    const versions = entries.filter(e => e.id === opts.id);
+    if (versions.length === 0) {
+      console.error(`No templates found with id "${opts.id}".`);
+      process.exit(1);
+    }
+    for (const e of versions) {
+      const ver = e.version !== undefined ? `v${e.version}` : '(no version)';
+      console.log(`${e.id}  ${ver}  [${e.source}]`);
+    }
+  } else {
+
+    // Deduplicate by id, show distinct ids
+    const seen = new Set();
+    for (const e of entries) {
+      if (seen.has(e.id)) continue;
+      seen.add(e.id);
+      console.log(`${e.id}  ${e.name !== e.id ? `(${e.name})` : ''}`);
+    }
+  }
+}
+
+async function runDownload(args) {
+
+  const options = {
+    id: { type: 'string' },
+    version: { type: 'string' }
+  };
+
+  const { values: opts } = parseArgsOrHelp(args, options, 'download');
+
+  if (!opts.id) {
+    console.error('Missing required option "--id". Run with --help for usage.');
+    process.exit(1);
+  }
+
+  const version = opts.version !== undefined ? Number(opts.version) : undefined;
+
+  if (opts.version !== undefined && isNaN(version)) {
+    console.error('--version must be a number.');
+    process.exit(1);
+  }
+
+  const { id, version: ver, file } = await downloadTemplate(opts.id, { version });
+
+  const verLabel = ver !== undefined ? `v${ver}` : '(no version)';
+  console.log(`Saved ${id} ${verLabel} → ${file}`);
+}
+
+async function resolveTemplate(opts) {
+  const templatePath = opts['template-path'] ?? opts.tp ?? opts.template;
+  const templateId = opts['template-id'] ?? opts.ti;
+
+  if (templatePath && templateId) {
+    throw new Error('Use only one of --template-path / --template-id.');
+  }
+
+  if (!templatePath && !templateId) {
+    throw new Error(
+      'Missing template source. Use --template-path <path> or --template-id <id>. ' +
+      'Run with --help for usage.'
+    );
+  }
+
+  if (templatePath) {
+    return resolveTemplatePath(templatePath);
+  }
+
+  return resolveTemplateId(templateId, { diagramPath: opts.diagram });
+}
+
 function requireOptions(opts, required) {
   for (const name of required) {
     if (opts[name] === undefined) {
-      console.error(`Missing required option "--${name}"`);
+      console.error(`Missing required option "--${name}". Run with --help for usage.`);
       process.exit(1);
     }
+  }
+}
+
+function parseArgsOrHelp(args, options, subcommand) {
+  try {
+    return parseArgs({ args, options });
+  } catch (err) {
+    console.error(`${err.message}\n\n${HELP[subcommand]}`);
+    process.exit(1);
   }
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 import { parseArgs } from 'node:util';
 
 import { readFile, writeFile } from 'node:fs/promises';
+import { stdin } from 'node:process';
 
 import {
   applyTemplate,
@@ -74,8 +75,8 @@ Usage: element-templates-cli set [options]
 Set field values on a BPMN element via an element template. Supports cascading
 condition re-evaluation so newly-visible fields can be set in the same call.
 
-Field keys in --values use the field label (e.g. "Label"). Use "Section.Label"
-to disambiguate fields with the same label in different sections. Duplicate
+Field keys use the field label (e.g. "Label"). Use "Section.Label" to
+disambiguate fields with the same label in different sections. Duplicate
 labels within a section are suffixed with "(N)" (e.g. "Label (2)").
 
 Constraints (notEmpty, pattern, minLength, maxLength) are enforced before applying.
@@ -85,11 +86,19 @@ Template source (exactly one required):
   --template-id,   --ti <id>     Template ID (e.g. io.camunda.connectors.HttpJson.v2)
   --template           <path>    Deprecated alias for --template-path
 
+Field values source (exactly one required):
+  --values       <json>        JSON object mapping field labels to values.
+                               Example: --values '{"Task Name": "my-task", "Retries": "3"}'
+                               Use --values - to read JSON from stdin.
+  --values-file  <path>        Read the JSON object from a file. Use this for large
+                               or special-character-heavy values to avoid shell escaping.
+  --target, -t   <field>       Set a single field. Must be paired with --value.
+  --value,  -v   <value>       The value for --target. Must be paired with --target.
+                               For multiple fields, use --values / --values-file.
+
 Options:
   --diagram   <path>     Path to the BPMN diagram file (required)
   --element   <id>       ID of the BPMN element to modify (required)
-  --values    <json>     JSON object mapping field labels to values (required)
-                         Example: --values '{"Task Name": "my-task", "Retries": "3"}'
   --output    <path>     Output path for the modified diagram; use "-" for stdout (default: "-")
   --help                 Show this help message
 `.trim(),
@@ -223,21 +232,76 @@ async function runSet(args) {
     diagram: { type: 'string' },
     element: { type: 'string' },
     values: { type: 'string' },
+    'values-file': { type: 'string' },
+    target: { type: 'string', short: 't' },
+    value: { type: 'string', short: 'v' },
     output: { type: 'string', default: '-' },
     ...TEMPLATE_OPTIONS
   };
 
   const { values: opts } = parseArgsOrHelp(args, options, 'set');
 
-  requireOptions(opts, [ 'diagram', 'element', 'values' ]);
+  requireOptions(opts, [ 'diagram', 'element' ]);
 
   const diagram = await readFile(opts.diagram, 'utf8');
   const template = await resolveTemplate(opts);
-  const fieldValues = parseValues(opts.values);
+  const fieldValues = await resolveFieldValues(opts);
 
   const xml = await setFields(diagram, template, opts.element, fieldValues);
 
   await output(xml, opts.output);
+}
+
+async function resolveFieldValues(opts) {
+  const hasTarget = opts.target !== undefined;
+  const hasValue = opts.value !== undefined;
+
+  if (hasTarget !== hasValue) {
+    console.error('--target and --value must be used together.');
+    process.exit(1);
+  }
+
+  const sources = [
+    opts.values !== undefined ? '--values' : null,
+    opts['values-file'] !== undefined ? '--values-file' : null,
+    hasTarget ? '--target/--value' : null
+  ].filter(Boolean);
+
+  if (sources.length === 0) {
+    console.error(
+      'Missing field values. Use --values, --values-file, or --target/--value. ' +
+      'Run with --help for usage.'
+    );
+    process.exit(1);
+  }
+
+  if (sources.length > 1) {
+    console.error(
+      `Use only one of --values / --values-file / --target+--value (got: ${sources.join(', ')}).`
+    );
+    process.exit(1);
+  }
+
+  if (hasTarget) {
+    return { [opts.target]: opts.value };
+  }
+
+  if (opts['values-file'] !== undefined) {
+    const raw = await readFile(opts['values-file'], 'utf8');
+    return parseValues(raw, opts['values-file']);
+  }
+
+  const raw = opts.values === '-' ? await readStdin() : opts.values;
+  return parseValues(raw, opts.values === '-' ? '<stdin>' : null);
+}
+
+async function readStdin() {
+  stdin.setEncoding('utf8');
+  let data = '';
+  for await (const chunk of stdin) {
+    data += chunk;
+  }
+  return data;
 }
 
 async function runList(args) {
@@ -339,11 +403,12 @@ function parseArgsOrHelp(args, options, subcommand) {
   }
 }
 
-function parseValues(raw) {
+function parseValues(raw, source) {
   try {
     return JSON.parse(raw);
   } catch (e) {
-    throw new Error(`Invalid JSON in --values: ${ e.message }`);
+    const where = source ? ` (${source})` : ' in --values';
+    throw new Error(`Invalid JSON${where}: ${ e.message }`);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "element-templates-cli": "bin/cli.js"
       },
       "devDependencies": {
-        "bpmn-js-element-templates": "^2.12.0",
+        "bpmn-js-element-templates": "file:../bpmn-js-element-templates",
         "bpmn-js-headless": "^0.1.0",
         "chai": "^6.0.0",
         "esbuild": "^0.25.5",
@@ -22,6 +22,89 @@
         "zeebe-bpmn-moddle": "^1.11.0"
       }
     },
+    "../bpmn-js-element-templates": {
+      "version": "2.23.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/element-templates-validator": "^2.20.1",
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "bpmnlint": "^11.12.0",
+        "classnames": "^2.5.1",
+        "ids": "^3.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "preact-markup": "^2.1.1",
+        "semver": "^7.7.4",
+        "semver-compare": "^1.0.0",
+        "uuid": "^13.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@bpmn-io/element-template-chooser": "^2.1.0",
+        "@bpmn-io/element-template-icon-renderer": "^1.0.0",
+        "@bpmn-io/properties-panel": "^3.40.2",
+        "@bpmn-io/variable-resolver": "^2.0.0",
+        "@camunda/linting": "^3.48.1",
+        "@rollup/plugin-alias": "^6.0.0",
+        "@rollup/plugin-babel": "^7.0.0",
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@testing-library/preact": "^2.0.1",
+        "@testing-library/preact-hooks": "^1.1.0",
+        "assert": "^2.1.0",
+        "babel-loader": "^10.0.0",
+        "babel-plugin-istanbul": "^7.0.1",
+        "bpmn-js": "^18.14.0",
+        "bpmn-js-create-append-anything": "^1.2.0",
+        "bpmn-js-properties-panel": "^5.52.1",
+        "bpmn-moddle": "^10.0.0",
+        "camunda-bpmn-js-behaviors": "^1.14.1",
+        "camunda-bpmn-moddle": "^7.0.1",
+        "chai": "^6.2.2",
+        "copy-webpack-plugin": "^14.0.0",
+        "cross-env": "^10.0.0",
+        "diagram-js": "^15.11.0",
+        "downloadjs": "^1.4.7",
+        "eslint": "^9.39.2",
+        "eslint-plugin-bpmn-io": "^2.2.0",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "file-drops": "^0.7.0",
+        "karma": "^6.4.4",
+        "karma-chrome-launcher-2": "^3.3.0",
+        "karma-coverage": "^2.2.1",
+        "karma-debug-launcher": "^0.0.5",
+        "karma-env-preprocessor": "^0.1.1",
+        "karma-mocha": "^2.0.1",
+        "karma-webpack": "^5.0.1",
+        "mocha": "^11.0.0",
+        "mocha-test-container-support": "^0.2.0",
+        "modeler-moddle": "^0.2.0",
+        "npm-run-all2": "^8.0.4",
+        "puppeteer": "^24.34.0",
+        "raw-loader": "^4.0.2",
+        "rollup": "^4.57.1",
+        "rollup-plugin-copy": "^3.5.0",
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "webpack": "^5.105.3",
+        "zeebe-bpmn-moddle": "^1.12.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">= 2.2",
+        "bpmn-js": ">= 11.5",
+        "bpmn-js-properties-panel": ">= 2",
+        "camunda-bpmn-js-behaviors": ">= 1.2.1",
+        "diagram-js": ">= 11.9"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -29,210 +112,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bpmn-io/cm-theme": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.4"
-      }
-    },
-    "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz",
-      "integrity": "sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "htm": "^3.1.1",
-        "preact": "^10.11.2"
-      }
-    },
-    "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.12.0.tgz",
-      "integrity": "sha512-kUtLx7PGeF68aoj15RCTftHL0p5iyYHSd5VyxWjitzybbVVptjF8z0pz5D9SboymUxa/vLO6nokcrZ1AyVw+TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.30.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^4.1.1"
-      }
-    },
-    "node_modules/@bpmn-io/element-templates-validator/node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.19.0.tgz",
-      "integrity": "sha512-KzINxW6J79ZN1N6aLMmeVv/RmY9yq28sQloWTzkz6x9oiZY2PnfM8SUHUKWctXbVM/SZY3jdPSngFZeg1++v6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@bpmn-io/extract-process-variables": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.8.0.tgz",
-      "integrity": "sha512-yAS7ZYX+D56K+luC36u96eRMLb4VHcPUwTUqMZ/Z/Je2gou2DJLRbuBTHAB4jjKt4wFCHSG4B8Y+TrBciEYf4w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^4.0.0"
-      }
-    },
-    "node_modules/@bpmn-io/feel-editor": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.9.0.tgz",
-      "integrity": "sha512-MowGZGk9abAmsfXW4PAHZ+wjqzLCMPMrSUWkYBhUm09/k4kAiiPaXBkDJareaENHmjph8bvH6wLPVntQMNc2xw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/feel-lint": "^0.2.0",
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/commands": "^6.2.4",
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/lint": "^6.4.0",
-        "@codemirror/state": "^6.1.4",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.6",
-        "lang-feel": "^1.0.0",
-        "min-dom": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/@bpmn-io/feel-lint": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.2.0.tgz",
-      "integrity": "sha512-Y1uMTEP87mAPijeBAyVae9oMMP/rymkqNJWZceC49uvVEmH+nCVz/qJarJDdfmqySThiYV6n+Yx/gzXs7FDrGw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/language": "^6.8.0",
-        "lezer-feel": "^1.0.1"
-      }
-    },
-    "node_modules/@bpmn-io/moddle-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.2.1.tgz",
-      "integrity": "sha512-iv9zwk7PEGupSq9bkVZNFL0ZmoJLHExlUcjsiYx200Nh3a5mH9BHXF+PLaSaiE4882KVEirklpWf3oQLAmShSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-dash": "^4.1.1"
-      }
-    },
-    "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.3.1.tgz",
-      "integrity": "sha512-GMOKYA04m8XrvzYi0wl7wh/N4zL7LJmrZNuJCZ2ZYJTuWpt8tIBwYIkFE4IzNpbXFGJoUcN7Y1QOdkKArJVMvw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/feel-editor": "^0.9.0",
-        "@codemirror/view": "^6.14.0",
-        "classnames": "^2.3.1",
-        "feelers": "^0.1.0",
-        "focus-trap": "^7.5.2",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.0.3"
-      }
-    },
-    "node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.12.1.tgz",
-      "integrity": "sha512-Hk0Fggw1fqsoeYXTC6/Ca5MyuseS3S2OAg6PGf9w7xcJf1RxJVHp20azAYhPK3bmgFXw/tBl/DMzZhyp+EDKtw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.30.0.tgz",
-      "integrity": "sha512-EX/0ruXTaHjxbqJSq8fFRqB2wjxKQBuErUYA5vXaxa4M4V3SO7t1aCdI5weCwKknOpdL91L+NWUZ7loq1QzK1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/autocomplete": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.0.tgz",
-      "integrity": "sha512-Fbwm0V/Wn3BkEJZRhr0hi5BhCo5a7eBL6LYaliPjOSwCyfOpnjXY59HruSxOUNV+1OYer0Tgx1zRNQttjXyDog==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.6.0",
-        "@lezer/common": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/commands": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
-      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.2.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/language": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
-      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/lint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
-      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/@codemirror/state": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
-      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-      "integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^6.1.4",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -916,44 +795,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@lezer/common": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
-      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@lezer/highlight": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
-      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/lr": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
-      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.0.tgz",
-      "integrity": "sha512-JYOI6Lkqbl83semCANkO3CKbKc0pONwinyagBufWBm+k4yhIcqfCF8B8fpEpvJLmIy7CAfwiq7dQ/PzUZA340g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1014,16 +855,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -1087,19 +918,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-move": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -1217,261 +1035,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/bpmn-js": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-13.2.2.tgz",
-      "integrity": "sha512-zH8uyfizZxEq2w1Z+AzDUuKkRyBml4KbnKLQH4XtgbQajhnMeyT6k9bcqag/dQL9s1CplCTv8N7EZFGvfMMsTA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "bpmn-moddle": "^8.0.0",
-        "diagram-js": "^12.2.0",
-        "diagram-js-direct-editing": "^2.0.0",
-        "ids": "^1.0.0",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.3",
-        "object-refs": "^0.3.0",
-        "tiny-svg": "^3.0.0"
-      }
-    },
     "node_modules/bpmn-js-element-templates": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.12.0.tgz",
-      "integrity": "sha512-5zK9sSN8y7+t1B07bzW/PQnTqCqaScvZE8dC4f+hElXlgjAEuLPcnMAbnTzl9GbP8ZVne5JtC2IcgOOA6Uyyew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.12.0",
-        "@bpmn-io/extract-process-variables": "^1.0.1",
-        "bpmnlint": "^11.6.0",
-        "classnames": "^2.5.1",
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^5.1.1",
-        "preact-markup": "^2.1.1",
-        "semver": "^7.7.1",
-        "semver-compare": "^1.0.0",
-        "uuid": "^11.1.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 2.2",
-        "bpmn-js": ">= 11.5",
-        "bpmn-js-properties-panel": ">= 2",
-        "camunda-bpmn-js-behaviors": ">= 1.2.1",
-        "diagram-js": ">= 11.9"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/@bpmn-io/extract-process-variables": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-1.0.1.tgz",
-      "integrity": "sha512-bisd1kL38HIjB+nmvtw3mpktH0Il3y55eiH/F7kKJs00jf+eksRBoUdr8q4Ge7w5uWxEKVszrasZCee5LTcYEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-dash": "^4.0.0"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/domify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-      "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/min-dom": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.1.1.tgz",
-      "integrity": "sha512-GaKUlguMAofd3OJsB0OkP17i5kucKqErgVCJxPawO9l5NwIPnr28SAr99zzlzMCWWljISBYrnZVWdE2Q92YGFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domify": "^2.0.0",
-        "min-dash": "^4.2.1"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
+      "resolved": "../bpmn-js-element-templates",
+      "link": true
     },
     "node_modules/bpmn-js-headless": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-headless/-/bpmn-js-headless-0.1.0.tgz",
       "integrity": "sha512-AdYHuEyxpLafJpWyUzak2/+rjqDZyk2l3EU186R/3W21x66dpeyPCAxt8n12TliQNudM9EZNzMmto79HNz715A==",
       "dev": true
-    },
-    "node_modules/bpmn-js-properties-panel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-4.0.2.tgz",
-      "integrity": "sha512-UhMRmXcmcDb7EvLHe7qvWGLEUsRmNn1m8mz4/1keonWFnvTy4HAblg+CecORc/tGtSBEI1CsrrPwA5qPZsHn0Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/element-templates-validator": "^0.14.0",
-        "@bpmn-io/extract-process-variables": "^0.8.0",
-        "array-move": "^3.0.1",
-        "classnames": "^2.3.1",
-        "ids": "^1.0.0",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.1.0",
-        "preact-markup": "^2.1.1",
-        "semver-compare": "^1.0.0",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.2",
-        "bpmn-js": ">= 11.5",
-        "camunda-bpmn-js-behaviors": ">= 0.4",
-        "diagram-js": ">= 11.9"
-      }
-    },
-    "node_modules/bpmn-js-properties-panel/node_modules/@bpmn-io/element-templates-validator": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.14.0.tgz",
-      "integrity": "sha512-b7/6AAFIG8e5mzgGZR7sLaQ/B36Iy0SKEdKvX7zYZVbguvqTP9GtBSAwDRSbJzKX0HKWSUfmjRFgfRhsjSNurA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.12.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.9.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^4.0.0"
-      }
-    },
-    "node_modules/bpmn-js-properties-panel/node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.9.0.tgz",
-      "integrity": "sha512-umeLoy8erTiFCG92Z29kJ8VH6fHfFE+75HwQH/WwIRqa2AvNYrkSCNpXtTGwW/EjnyvGA6VcfqirZhibuuHMaA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/bpmn-moddle": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.1.0.tgz",
-      "integrity": "sha512-yI5OAFfYVJwViKTsTsonVfCBPtB3MlefADUORwNIxxBOMp21vnoxuxsdgUWlPH/dvAEZh/+mr8UtqOBNu8NC5Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.2.3",
-        "moddle-xml": "^10.1.0"
-      }
-    },
-    "node_modules/bpmnlint": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.6.0.tgz",
-      "integrity": "sha512-QpzSVb6nigi3tWV/9hHbcUGcxt3/36Rk5PU8xBq96qljn9y4B13aiWk2kWnF1iKBidKZzOFQXrtkU/MGjb2Qpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/moddle-utils": "^0.2.1",
-        "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^9.0.1",
-        "bpmnlint-utils": "^1.1.1",
-        "cli-table": "^0.3.11",
-        "color-support": "^1.1.3",
-        "min-dash": "^4.2.3",
-        "mri": "^1.2.0",
-        "pluralize": "^7.0.0",
-        "tiny-glob": "^0.2.9"
-      },
-      "bin": {
-        "bpmnlint": "bin/bpmnlint.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/bpmnlint-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
-      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bpmnlint/node_modules/bpmn-moddle": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.3.tgz",
-      "integrity": "sha512-Mv9KKKSaH5PsN5b1j7GoLfsQ9Ortm5o9Rj7Xy9hnsOhUSUJWIvlch//qYPUvaE6CS4uR6dtujOPum7mLIhl6xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-dash": "^4.2.1",
-        "moddle": "^7.0.0",
-        "moddle-xml": "^11.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/bpmnlint/node_modules/moddle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
-      "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-dash": "^4.2.1"
-      }
-    },
-    "node_modules/bpmnlint/node_modules/moddle-xml": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
-      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-dash": "^4.0.0",
-        "saxen": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "moddle": ">= 6.2.0"
-      }
-    },
-    "node_modules/bpmnlint/node_modules/saxen": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1529,29 +1101,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.2.2.tgz",
-      "integrity": "sha512-BYbiKH5L3tMqpFOnmlIOp2QR/8ewNG0UOIOVafBYuZCiBOXr/XMl86gOF0aT994xdOGKO/6gdqc7+p8baAxcEw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0"
-      },
-      "peerDependencies": {
-        "bpmn-js": ">= 9",
-        "camunda-bpmn-moddle": ">= 7",
-        "zeebe-bpmn-moddle": ">= 0.18"
-      }
-    },
-    "node_modules/camunda-bpmn-moddle": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
-      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.1",
@@ -1621,25 +1170,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cli-table": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
-      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1689,16 +1219,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1717,45 +1237,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/component-event": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1892,46 +1378,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/diagram-js": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.2.0.tgz",
-      "integrity": "sha512-CXo/qc2KJz663t2b7AlrkeMCo4SdVZMNxq4oNwUN6QzbWesnbjNCwS9aptIDFkpBjXRGtgOzf/T6D6QaVJfTqw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.2",
-        "clsx": "^1.2.1",
-        "didi": "^9.0.2",
-        "hammerjs": "^2.0.1",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.0",
-        "min-dom": "^4.1.0",
-        "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
-        "tiny-svg": "^3.0.1"
-      }
-    },
-    "node_modules/diagram-js-direct-editing": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.0.0.tgz",
-      "integrity": "sha512-/12OWL0B0RMCfaT1w3723c729MD42r5fay4wtm2DvxNFNBMdPaEvOHCTA/khLKjFzOzMVKxSzbAp7IEwBGonVw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.2"
-      },
-      "peerDependencies": {
-        "diagram-js": "*"
-      }
-    },
-    "node_modules/didi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.2.tgz",
-      "integrity": "sha512-q2+aj+lnJcUweV7A9pdUrwFr4LHVmRPwTmQLtHPFz4aT7IBoryN6Iy+jmFku+oIzr5ebBkvtBCOb87+dJhb7bg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -1941,13 +1387,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/domify": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2512,72 +1951,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/feelers": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/feelers/-/feelers-0.1.0.tgz",
-      "integrity": "sha512-gvF3VkrCIQIiYehB51JYjvADkT36eMQKfVPWyDYrbG1bfc9+Y7bvjdzhLgxEuk2BvFaYj1amRyqgOTXkP+gYUw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
-        "@bpmn-io/feel-lint": "^0.1.1",
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/commands": "^6.1.2",
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/lint": "^6.1.0",
-        "@codemirror/state": "^6.1.4",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/markdown": "^1.0.2",
-        "feelin": "^1.0.0",
-        "lezer-feel": "^0.16.2",
-        "min-dom": "^4.1.0"
-      }
-    },
-    "node_modules/feelers/node_modules/@bpmn-io/feel-lint": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.1.tgz",
-      "integrity": "sha512-MUuBHtKJhvDifnQmPZhvFpr/ps3eT5M7+g792OYOy17lGgSVrW7NlFu1JugWCKueZSFv0loj1Xy6LmEZG2PUQg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/language": "^6.2.1",
-        "lezer-feel": "^0.15.0"
-      }
-    },
-    "node_modules/feelers/node_modules/@bpmn-io/feel-lint/node_modules/lezer-feel": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.15.0.tgz",
-      "integrity": "sha512-coal496AMZ61XSBN6z2LC704to5EpRLHLq4RIetvdj8RMfHM02PDRfqQy0JPACS6CaWydW8ESCekkirsuc+cgA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/highlight": "^1.1.2",
-        "@lezer/lr": "^1.2.5"
-      }
-    },
-    "node_modules/feelers/node_modules/lezer-feel": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.16.2.tgz",
-      "integrity": "sha512-G9heYUw4ibeNWFmlhs8yR/QEDd6OAFvv2e7F2x1zOhxqYKKEBXhXQEIvQh1psgQMJjQSuUvVZRxPbnjfvGq/Bw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/highlight": "^1.1.2",
-        "@lezer/lr": "^1.2.5"
-      }
-    },
-    "node_modules/feelin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/feelin/-/feelin-1.0.0.tgz",
-      "integrity": "sha512-ED1pbRGivpxPHjMBssCivkuAWGm3ma0yK46DqcUlA8KP1Rz5Limjg8YENBRsyc1ZSoSkpboVuscqWmXw2Cl03A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/lr": "^1.3.9",
-        "lezer-feel": "^1.0.0",
-        "luxon": "^3.1.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2633,16 +2006,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "tabbable": "^6.2.0"
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -2836,20 +2199,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -2860,16 +2209,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/has-bigints": {
@@ -2962,19 +2301,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/htm": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/ids": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3010,13 +2336,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inherits-browser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -3467,12 +2786,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
-      "dev": true
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3503,21 +2816,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/lang-feel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-1.0.0.tgz",
-      "integrity": "sha512-lMicLS2eTvT7Hw5nDv2BAwjpebY0QP930CAKgglSt4TjqxIUIhSGYLV2KWdNjlSheL/0iDHkxJUH+ZG1Y1KRWg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.8.1",
-        "@codemirror/language": "^6.8.0",
-        "@codemirror/state": "^6.2.1",
-        "@codemirror/view": "^6.14.0",
-        "@lezer/common": "^1.0.3",
-        "lezer-feel": "^1.0.0"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3529,17 +2827,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lezer-feel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.0.2.tgz",
-      "integrity": "sha512-WEqRVhYZNOr6+aTWfS2CLVX1ebS1KeQjTeVQVgzXkGNC0AqmFWcRwEgAGm3FHKE66cxj3RPKx7T+ofr6FzmJjQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.3.9"
       }
     },
     "node_modules/locate-path": {
@@ -3596,35 +2883,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
-    },
-    "node_modules/luxon": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.0.tgz",
-      "integrity": "sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/min-dash": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.3.tgz",
-      "integrity": "sha512-VLMYQI5+FcD9Ad24VcB08uA83B07OhueAlZ88jBK6PyupTvEJwllTMUqMy0wPGYs7pZUEtEEMWdHB63m3LtEcg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3709,38 +2967,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/moddle": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.3.tgz",
-      "integrity": "sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^4.0.0"
-      }
-    },
-    "node_modules/moddle-xml": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
-      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.0.0",
-        "saxen": "^8.1.2"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3782,13 +3008,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/object-refs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.3.0.tgz",
-      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/object.assign": {
       "version": "4.1.5",
@@ -3932,13 +3151,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-intersection": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
-      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3977,16 +3189,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -3994,26 +3196,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/preact": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
-      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/preact-markup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
-      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
-      "dev": true,
-      "peerDependencies": {
-        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -4212,13 +3394,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/saxen": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
-      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4227,12 +3402,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -4477,13 +3646,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-mod": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
-      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4510,31 +3672,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
-      }
-    },
-    "node_modules/tiny-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.1.tgz",
-      "integrity": "sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4657,27 +3794,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4959,199 +4075,6 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
-    },
-    "@bpmn-io/cm-theme": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.4"
-      }
-    },
-    "@bpmn-io/diagram-js-ui": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz",
-      "integrity": "sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "htm": "^3.1.1",
-        "preact": "^10.11.2"
-      }
-    },
-    "@bpmn-io/element-templates-validator": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.12.0.tgz",
-      "integrity": "sha512-kUtLx7PGeF68aoj15RCTftHL0p5iyYHSd5VyxWjitzybbVVptjF8z0pz5D9SboymUxa/vLO6nokcrZ1AyVw+TA==",
-      "dev": true,
-      "requires": {
-        "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.30.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^4.1.1"
-      },
-      "dependencies": {
-        "@camunda/element-templates-json-schema": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.19.0.tgz",
-          "integrity": "sha512-KzINxW6J79ZN1N6aLMmeVv/RmY9yq28sQloWTzkz6x9oiZY2PnfM8SUHUKWctXbVM/SZY3jdPSngFZeg1++v6A==",
-          "dev": true
-        }
-      }
-    },
-    "@bpmn-io/extract-process-variables": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.8.0.tgz",
-      "integrity": "sha512-yAS7ZYX+D56K+luC36u96eRMLb4VHcPUwTUqMZ/Z/Je2gou2DJLRbuBTHAB4jjKt4wFCHSG4B8Y+TrBciEYf4w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^4.0.0"
-      }
-    },
-    "@bpmn-io/feel-editor": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.9.0.tgz",
-      "integrity": "sha512-MowGZGk9abAmsfXW4PAHZ+wjqzLCMPMrSUWkYBhUm09/k4kAiiPaXBkDJareaENHmjph8bvH6wLPVntQMNc2xw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/feel-lint": "^0.2.0",
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/commands": "^6.2.4",
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/lint": "^6.4.0",
-        "@codemirror/state": "^6.1.4",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.6",
-        "lang-feel": "^1.0.0",
-        "min-dom": "^4.1.0"
-      }
-    },
-    "@bpmn-io/feel-lint": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.2.0.tgz",
-      "integrity": "sha512-Y1uMTEP87mAPijeBAyVae9oMMP/rymkqNJWZceC49uvVEmH+nCVz/qJarJDdfmqySThiYV6n+Yx/gzXs7FDrGw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/language": "^6.8.0",
-        "lezer-feel": "^1.0.1"
-      }
-    },
-    "@bpmn-io/moddle-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.2.1.tgz",
-      "integrity": "sha512-iv9zwk7PEGupSq9bkVZNFL0ZmoJLHExlUcjsiYx200Nh3a5mH9BHXF+PLaSaiE4882KVEirklpWf3oQLAmShSA==",
-      "dev": true,
-      "requires": {
-        "min-dash": "^4.1.1"
-      }
-    },
-    "@bpmn-io/properties-panel": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.3.1.tgz",
-      "integrity": "sha512-GMOKYA04m8XrvzYi0wl7wh/N4zL7LJmrZNuJCZ2ZYJTuWpt8tIBwYIkFE4IzNpbXFGJoUcN7Y1QOdkKArJVMvw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/feel-editor": "^0.9.0",
-        "@codemirror/view": "^6.14.0",
-        "classnames": "^2.3.1",
-        "feelers": "^0.1.0",
-        "focus-trap": "^7.5.2",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.0.3"
-      }
-    },
-    "@camunda/element-templates-json-schema": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.12.1.tgz",
-      "integrity": "sha512-Hk0Fggw1fqsoeYXTC6/Ca5MyuseS3S2OAg6PGf9w7xcJf1RxJVHp20azAYhPK3bmgFXw/tBl/DMzZhyp+EDKtw==",
-      "dev": true,
-      "peer": true
-    },
-    "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.30.0.tgz",
-      "integrity": "sha512-EX/0ruXTaHjxbqJSq8fFRqB2wjxKQBuErUYA5vXaxa4M4V3SO7t1aCdI5weCwKknOpdL91L+NWUZ7loq1QzK1w==",
-      "dev": true
-    },
-    "@codemirror/autocomplete": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.0.tgz",
-      "integrity": "sha512-Fbwm0V/Wn3BkEJZRhr0hi5BhCo5a7eBL6LYaliPjOSwCyfOpnjXY59HruSxOUNV+1OYer0Tgx1zRNQttjXyDog==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.6.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "@codemirror/commands": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
-      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.2.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "@codemirror/language": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
-      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "@codemirror/lint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
-      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "@codemirror/state": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
-      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
-      "dev": true,
-      "peer": true
-    },
-    "@codemirror/view": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-      "integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/state": "^6.1.4",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -5492,44 +4415,6 @@
         }
       }
     },
-    "@lezer/common": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
-      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==",
-      "dev": true,
-      "peer": true
-    },
-    "@lezer/highlight": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
-      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "@lezer/lr": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
-      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "@lezer/markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.0.tgz",
-      "integrity": "sha512-JYOI6Lkqbl83semCANkO3CKbKc0pONwinyagBufWBm+k4yhIcqfCF8B8fpEpvJLmIy7CAfwiq7dQ/PzUZA340g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0"
-      }
-    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5574,12 +4459,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5621,13 +4500,6 @@
         "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       }
-    },
-    "array-move": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
-      "dev": true,
-      "peer": true
     },
     "array.prototype.findlast": {
       "version": "1.2.5",
@@ -5711,201 +4583,79 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bpmn-js": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-13.2.2.tgz",
-      "integrity": "sha512-zH8uyfizZxEq2w1Z+AzDUuKkRyBml4KbnKLQH4XtgbQajhnMeyT6k9bcqag/dQL9s1CplCTv8N7EZFGvfMMsTA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "bpmn-moddle": "^8.0.0",
-        "diagram-js": "^12.2.0",
-        "diagram-js-direct-editing": "^2.0.0",
-        "ids": "^1.0.0",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.3",
-        "object-refs": "^0.3.0",
-        "tiny-svg": "^3.0.0"
-      }
-    },
     "bpmn-js-element-templates": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.12.0.tgz",
-      "integrity": "sha512-5zK9sSN8y7+t1B07bzW/PQnTqCqaScvZE8dC4f+hElXlgjAEuLPcnMAbnTzl9GbP8ZVne5JtC2IcgOOA6Uyyew==",
-      "dev": true,
+      "version": "file:../bpmn-js-element-templates",
       "requires": {
-        "@bpmn-io/element-templates-validator": "^2.12.0",
-        "@bpmn-io/extract-process-variables": "^1.0.1",
-        "bpmnlint": "^11.6.0",
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@bpmn-io/element-template-chooser": "^2.1.0",
+        "@bpmn-io/element-template-icon-renderer": "^1.0.0",
+        "@bpmn-io/element-templates-validator": "^2.20.1",
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "@bpmn-io/properties-panel": "^3.40.2",
+        "@bpmn-io/variable-resolver": "^2.0.0",
+        "@camunda/linting": "^3.48.1",
+        "@rollup/plugin-alias": "^6.0.0",
+        "@rollup/plugin-babel": "^7.0.0",
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@testing-library/preact": "^2.0.1",
+        "@testing-library/preact-hooks": "^1.1.0",
+        "assert": "^2.1.0",
+        "babel-loader": "^10.0.0",
+        "babel-plugin-istanbul": "^7.0.1",
+        "bpmn-js": "^18.14.0",
+        "bpmn-js-create-append-anything": "^1.2.0",
+        "bpmn-js-properties-panel": "^5.52.1",
+        "bpmn-moddle": "^10.0.0",
+        "bpmnlint": "^11.12.0",
+        "camunda-bpmn-js-behaviors": "^1.14.1",
+        "camunda-bpmn-moddle": "^7.0.1",
+        "chai": "^6.2.2",
         "classnames": "^2.5.1",
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^5.1.1",
+        "copy-webpack-plugin": "^14.0.0",
+        "cross-env": "^10.0.0",
+        "diagram-js": "^15.11.0",
+        "downloadjs": "^1.4.7",
+        "eslint": "^9.39.2",
+        "eslint-plugin-bpmn-io": "^2.2.0",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "file-drops": "^0.7.0",
+        "ids": "^3.0.0",
+        "karma": "^6.4.4",
+        "karma-chrome-launcher-2": "^3.3.0",
+        "karma-coverage": "^2.2.1",
+        "karma-debug-launcher": "^0.0.5",
+        "karma-env-preprocessor": "^0.1.1",
+        "karma-mocha": "^2.0.1",
+        "karma-webpack": "^5.0.1",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "mocha": "^11.0.0",
+        "mocha-test-container-support": "^0.2.0",
+        "modeler-moddle": "^0.2.0",
+        "npm-run-all2": "^8.0.4",
         "preact-markup": "^2.1.1",
-        "semver": "^7.7.1",
+        "puppeteer": "^24.34.0",
+        "raw-loader": "^4.0.2",
+        "rollup": "^4.57.1",
+        "rollup-plugin-copy": "^3.5.0",
+        "semver": "^7.7.4",
         "semver-compare": "^1.0.0",
-        "uuid": "^11.1.0"
-      },
-      "dependencies": {
-        "@bpmn-io/extract-process-variables": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-1.0.1.tgz",
-          "integrity": "sha512-bisd1kL38HIjB+nmvtw3mpktH0Il3y55eiH/F7kKJs00jf+eksRBoUdr8q4Ge7w5uWxEKVszrasZCee5LTcYEw==",
-          "dev": true,
-          "requires": {
-            "min-dash": "^4.0.0"
-          }
-        },
-        "domify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-          "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
-          "dev": true
-        },
-        "min-dom": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.1.1.tgz",
-          "integrity": "sha512-GaKUlguMAofd3OJsB0OkP17i5kucKqErgVCJxPawO9l5NwIPnr28SAr99zzlzMCWWljISBYrnZVWdE2Q92YGFQ==",
-          "dev": true,
-          "requires": {
-            "domify": "^2.0.0",
-            "min-dash": "^4.2.1"
-          }
-        },
-        "semver": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-          "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-          "dev": true
-        }
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "uuid": "^13.0.0",
+        "webpack": "^5.105.3",
+        "zeebe-bpmn-moddle": "^1.12.0"
       }
     },
     "bpmn-js-headless": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-headless/-/bpmn-js-headless-0.1.0.tgz",
       "integrity": "sha512-AdYHuEyxpLafJpWyUzak2/+rjqDZyk2l3EU186R/3W21x66dpeyPCAxt8n12TliQNudM9EZNzMmto79HNz715A==",
-      "dev": true
-    },
-    "bpmn-js-properties-panel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-4.0.2.tgz",
-      "integrity": "sha512-UhMRmXcmcDb7EvLHe7qvWGLEUsRmNn1m8mz4/1keonWFnvTy4HAblg+CecORc/tGtSBEI1CsrrPwA5qPZsHn0Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/element-templates-validator": "^0.14.0",
-        "@bpmn-io/extract-process-variables": "^0.8.0",
-        "array-move": "^3.0.1",
-        "classnames": "^2.3.1",
-        "ids": "^1.0.0",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.1.0",
-        "preact-markup": "^2.1.1",
-        "semver-compare": "^1.0.0",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@bpmn-io/element-templates-validator": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.14.0.tgz",
-          "integrity": "sha512-b7/6AAFIG8e5mzgGZR7sLaQ/B36Iy0SKEdKvX7zYZVbguvqTP9GtBSAwDRSbJzKX0HKWSUfmjRFgfRhsjSNurA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@camunda/element-templates-json-schema": "^0.12.1",
-            "@camunda/zeebe-element-templates-json-schema": "^0.9.0",
-            "json-source-map": "^0.6.1",
-            "min-dash": "^4.0.0"
-          }
-        },
-        "@camunda/zeebe-element-templates-json-schema": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.9.0.tgz",
-          "integrity": "sha512-umeLoy8erTiFCG92Z29kJ8VH6fHfFE+75HwQH/WwIRqa2AvNYrkSCNpXtTGwW/EjnyvGA6VcfqirZhibuuHMaA==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "bpmn-moddle": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.1.0.tgz",
-      "integrity": "sha512-yI5OAFfYVJwViKTsTsonVfCBPtB3MlefADUORwNIxxBOMp21vnoxuxsdgUWlPH/dvAEZh/+mr8UtqOBNu8NC5Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.2.3",
-        "moddle-xml": "^10.1.0"
-      }
-    },
-    "bpmnlint": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.6.0.tgz",
-      "integrity": "sha512-QpzSVb6nigi3tWV/9hHbcUGcxt3/36Rk5PU8xBq96qljn9y4B13aiWk2kWnF1iKBidKZzOFQXrtkU/MGjb2Qpg==",
-      "dev": true,
-      "requires": {
-        "@bpmn-io/moddle-utils": "^0.2.1",
-        "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^9.0.1",
-        "bpmnlint-utils": "^1.1.1",
-        "cli-table": "^0.3.11",
-        "color-support": "^1.1.3",
-        "min-dash": "^4.2.3",
-        "mri": "^1.2.0",
-        "pluralize": "^7.0.0",
-        "tiny-glob": "^0.2.9"
-      },
-      "dependencies": {
-        "bpmn-moddle": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.3.tgz",
-          "integrity": "sha512-Mv9KKKSaH5PsN5b1j7GoLfsQ9Ortm5o9Rj7Xy9hnsOhUSUJWIvlch//qYPUvaE6CS4uR6dtujOPum7mLIhl6xQ==",
-          "dev": true,
-          "requires": {
-            "min-dash": "^4.2.1",
-            "moddle": "^7.0.0",
-            "moddle-xml": "^11.0.0"
-          }
-        },
-        "moddle": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
-          "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
-          "dev": true,
-          "requires": {
-            "min-dash": "^4.2.1"
-          }
-        },
-        "moddle-xml": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
-          "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
-          "dev": true,
-          "requires": {
-            "min-dash": "^4.0.0",
-            "saxen": "^10.0.0"
-          }
-        },
-        "saxen": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-          "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
-          "dev": true
-        }
-      }
-    },
-    "bpmnlint-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
-      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
       "dev": true
     },
     "brace-expansion": {
@@ -5948,24 +4698,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
-    },
-    "camunda-bpmn-js-behaviors": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.2.2.tgz",
-      "integrity": "sha512-BYbiKH5L3tMqpFOnmlIOp2QR/8ewNG0UOIOVafBYuZCiBOXr/XMl86gOF0aT994xdOGKO/6gdqc7+p8baAxcEw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0"
-      }
-    },
-    "camunda-bpmn-moddle": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
-      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
-      "dev": true,
-      "peer": true
     },
     "chai": {
       "version": "6.2.1",
@@ -6012,21 +4744,6 @@
         "readdirp": "^4.0.1"
       }
     },
-    "classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "dev": true
-    },
-    "cli-table": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
-      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      }
-    },
     "cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6060,13 +4777,6 @@
         }
       }
     },
-    "clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true,
-      "peer": true
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6082,37 +4792,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "dev": true
-    },
-    "component-event": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true,
-      "peer": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "peer": true
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -6201,55 +4885,11 @@
         "object-keys": "^1.1.1"
       }
     },
-    "diagram-js": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.2.0.tgz",
-      "integrity": "sha512-CXo/qc2KJz663t2b7AlrkeMCo4SdVZMNxq4oNwUN6QzbWesnbjNCwS9aptIDFkpBjXRGtgOzf/T6D6QaVJfTqw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/diagram-js-ui": "^0.2.2",
-        "clsx": "^1.2.1",
-        "didi": "^9.0.2",
-        "hammerjs": "^2.0.1",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.0",
-        "min-dom": "^4.1.0",
-        "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
-        "tiny-svg": "^3.0.1"
-      }
-    },
-    "diagram-js-direct-editing": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.0.0.tgz",
-      "integrity": "sha512-/12OWL0B0RMCfaT1w3723c729MD42r5fay4wtm2DvxNFNBMdPaEvOHCTA/khLKjFzOzMVKxSzbAp7IEwBGonVw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.2"
-      }
-    },
-    "didi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.2.tgz",
-      "integrity": "sha512-q2+aj+lnJcUweV7A9pdUrwFr4LHVmRPwTmQLtHPFz4aT7IBoryN6Iy+jmFku+oIzr5ebBkvtBCOb87+dJhb7bg==",
-      "dev": true,
-      "peer": true
-    },
     "diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true
-    },
-    "domify": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true,
-      "peer": true
     },
     "eastasianwidth": {
       "version": "0.2.0",
@@ -6668,76 +5308,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "feelers": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/feelers/-/feelers-0.1.0.tgz",
-      "integrity": "sha512-gvF3VkrCIQIiYehB51JYjvADkT36eMQKfVPWyDYrbG1bfc9+Y7bvjdzhLgxEuk2BvFaYj1amRyqgOTXkP+gYUw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
-        "@bpmn-io/feel-lint": "^0.1.1",
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/commands": "^6.1.2",
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/lint": "^6.1.0",
-        "@codemirror/state": "^6.1.4",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/markdown": "^1.0.2",
-        "feelin": "^1.0.0",
-        "lezer-feel": "^0.16.2",
-        "min-dom": "^4.1.0"
-      },
-      "dependencies": {
-        "@bpmn-io/feel-lint": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.1.tgz",
-          "integrity": "sha512-MUuBHtKJhvDifnQmPZhvFpr/ps3eT5M7+g792OYOy17lGgSVrW7NlFu1JugWCKueZSFv0loj1Xy6LmEZG2PUQg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@codemirror/language": "^6.2.1",
-            "lezer-feel": "^0.15.0"
-          },
-          "dependencies": {
-            "lezer-feel": {
-              "version": "0.15.0",
-              "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.15.0.tgz",
-              "integrity": "sha512-coal496AMZ61XSBN6z2LC704to5EpRLHLq4RIetvdj8RMfHM02PDRfqQy0JPACS6CaWydW8ESCekkirsuc+cgA==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "@lezer/highlight": "^1.1.2",
-                "@lezer/lr": "^1.2.5"
-              }
-            }
-          }
-        },
-        "lezer-feel": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.16.2.tgz",
-          "integrity": "sha512-G9heYUw4ibeNWFmlhs8yR/QEDd6OAFvv2e7F2x1zOhxqYKKEBXhXQEIvQh1psgQMJjQSuUvVZRxPbnjfvGq/Bw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@lezer/highlight": "^1.1.2",
-            "@lezer/lr": "^1.2.5"
-          }
-        }
-      }
-    },
-    "feelin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/feelin/-/feelin-1.0.0.tgz",
-      "integrity": "sha512-ED1pbRGivpxPHjMBssCivkuAWGm3ma0yK46DqcUlA8KP1Rz5Limjg8YENBRsyc1ZSoSkpboVuscqWmXw2Cl03A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@lezer/lr": "^1.3.9",
-        "lezer-feel": "^1.0.0",
-        "luxon": "^3.1.0"
-      }
-    },
     "file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6778,16 +5348,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "tabbable": "^6.2.0"
-      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -6921,18 +5481,6 @@
         "gopd": "^1.0.1"
       }
     },
-    "globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "dev": true
-    },
-    "globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
-    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6941,13 +5489,6 @@
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
-      "dev": true,
-      "peer": true
     },
     "has-bigints": {
       "version": "1.0.2",
@@ -7006,19 +5547,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "htm": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true,
-      "peer": true
-    },
-    "ids": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
-    },
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7040,13 +5568,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
-    },
-    "inherits-browser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
-      "dev": true,
-      "peer": true
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -7341,12 +5862,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
-      "dev": true
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -7374,21 +5889,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "lang-feel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-1.0.0.tgz",
-      "integrity": "sha512-lMicLS2eTvT7Hw5nDv2BAwjpebY0QP930CAKgglSt4TjqxIUIhSGYLV2KWdNjlSheL/0iDHkxJUH+ZG1Y1KRWg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@codemirror/autocomplete": "^6.8.1",
-        "@codemirror/language": "^6.8.0",
-        "@codemirror/state": "^6.2.1",
-        "@codemirror/view": "^6.14.0",
-        "@lezer/common": "^1.0.3",
-        "lezer-feel": "^1.0.0"
-      }
-    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7397,17 +5897,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "lezer-feel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.0.2.tgz",
-      "integrity": "sha512-WEqRVhYZNOr6+aTWfS2CLVX1ebS1KeQjTeVQVgzXkGNC0AqmFWcRwEgAGm3FHKE66cxj3RPKx7T+ofr6FzmJjQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.3.9"
       }
     },
     "locate-path": {
@@ -7449,31 +5938,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
-    },
-    "luxon": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.0.tgz",
-      "integrity": "sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==",
-      "dev": true,
-      "peer": true
-    },
-    "min-dash": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.3.tgz",
-      "integrity": "sha512-VLMYQI5+FcD9Ad24VcB08uA83B07OhueAlZ88jBK6PyupTvEJwllTMUqMy0wPGYs7pZUEtEEMWdHB63m3LtEcg==",
-      "dev": true
-    },
-    "min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
     },
     "minimatch": {
       "version": "3.1.2",
@@ -7538,34 +6002,6 @@
         }
       }
     },
-    "moddle": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.3.tgz",
-      "integrity": "sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^4.0.0"
-      }
-    },
-    "moddle-xml": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
-      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.0.0",
-        "saxen": "^8.1.2"
-      }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7595,13 +6031,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
-    },
-    "object-refs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.3.0.tgz",
-      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ==",
-      "dev": true,
-      "peer": true
     },
     "object.assign": {
       "version": "4.1.5",
@@ -7702,13 +6131,6 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
-    "path-intersection": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
-      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
-      "dev": true,
-      "peer": true
-    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7737,31 +6159,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
     "possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true
-    },
-    "preact": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
-      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
-      "dev": true,
-      "peer": true
-    },
-    "preact-markup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
-      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
-      "dev": true,
-      "requires": {}
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -7892,23 +6294,10 @@
         "is-regex": "^1.1.4"
       }
     },
-    "saxen": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
-      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw==",
-      "dev": true,
-      "peer": true
-    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
     },
     "serialize-javascript": {
@@ -8089,13 +6478,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "style-mod": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
-      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==",
-      "dev": true,
-      "peer": true
-    },
     "supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -8110,30 +6492,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true,
-      "peer": true
-    },
-    "tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "dev": true,
-      "requires": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
-      }
-    },
-    "tiny-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.1.tgz",
-      "integrity": "sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg==",
-      "dev": true,
-      "peer": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -8222,20 +6580,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "peer": true
-    },
-    "w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
-      "peer": true
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "element-templates-cli": "bin/cli.js"
       },
       "devDependencies": {
-        "bpmn-js-element-templates": "file:../bpmn-js-element-templates",
+        "bpmn-js-element-templates": "github:vringar/bpmn-js-element-templates#feat/export-util-subpath",
         "bpmn-js-headless": "^0.1.0",
         "chai": "^6.0.0",
         "esbuild": "^0.25.5",
@@ -22,89 +22,6 @@
         "zeebe-bpmn-moddle": "^1.11.0"
       }
     },
-    "../bpmn-js-element-templates": {
-      "version": "2.23.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.20.1",
-        "@bpmn-io/extract-process-variables": "^2.2.1",
-        "bpmnlint": "^11.12.0",
-        "classnames": "^2.5.1",
-        "ids": "^3.0.0",
-        "min-dash": "^5.0.0",
-        "min-dom": "^5.3.0",
-        "preact-markup": "^2.1.1",
-        "semver": "^7.7.4",
-        "semver-compare": "^1.0.0",
-        "uuid": "^13.0.0"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.28.5",
-        "@babel/plugin-transform-react-jsx": "^7.27.1",
-        "@bpmn-io/element-template-chooser": "^2.1.0",
-        "@bpmn-io/element-template-icon-renderer": "^1.0.0",
-        "@bpmn-io/properties-panel": "^3.40.2",
-        "@bpmn-io/variable-resolver": "^2.0.0",
-        "@camunda/linting": "^3.48.1",
-        "@rollup/plugin-alias": "^6.0.0",
-        "@rollup/plugin-babel": "^7.0.0",
-        "@rollup/plugin-commonjs": "^29.0.0",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^16.0.3",
-        "@rollup/plugin-replace": "^6.0.3",
-        "@testing-library/preact": "^2.0.1",
-        "@testing-library/preact-hooks": "^1.1.0",
-        "assert": "^2.1.0",
-        "babel-loader": "^10.0.0",
-        "babel-plugin-istanbul": "^7.0.1",
-        "bpmn-js": "^18.14.0",
-        "bpmn-js-create-append-anything": "^1.2.0",
-        "bpmn-js-properties-panel": "^5.52.1",
-        "bpmn-moddle": "^10.0.0",
-        "camunda-bpmn-js-behaviors": "^1.14.1",
-        "camunda-bpmn-moddle": "^7.0.1",
-        "chai": "^6.2.2",
-        "copy-webpack-plugin": "^14.0.0",
-        "cross-env": "^10.0.0",
-        "diagram-js": "^15.11.0",
-        "downloadjs": "^1.4.7",
-        "eslint": "^9.39.2",
-        "eslint-plugin-bpmn-io": "^2.2.0",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "file-drops": "^0.7.0",
-        "karma": "^6.4.4",
-        "karma-chrome-launcher-2": "^3.3.0",
-        "karma-coverage": "^2.2.1",
-        "karma-debug-launcher": "^0.0.5",
-        "karma-env-preprocessor": "^0.1.1",
-        "karma-mocha": "^2.0.1",
-        "karma-webpack": "^5.0.1",
-        "mocha": "^11.0.0",
-        "mocha-test-container-support": "^0.2.0",
-        "modeler-moddle": "^0.2.0",
-        "npm-run-all2": "^8.0.4",
-        "puppeteer": "^24.34.0",
-        "raw-loader": "^4.0.2",
-        "rollup": "^4.57.1",
-        "rollup-plugin-copy": "^3.5.0",
-        "sinon": "^21.0.0",
-        "sinon-chai": "^4.0.0",
-        "webpack": "^5.105.3",
-        "zeebe-bpmn-moddle": "^1.12.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 2.2",
-        "bpmn-js": ">= 11.5",
-        "bpmn-js-properties-panel": ">= 2",
-        "camunda-bpmn-js-behaviors": ">= 1.2.1",
-        "diagram-js": ">= 11.9"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -112,6 +29,296 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@bpmn-io/cm-theme": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/language": "^6.3.1",
+        "@codemirror/view": "^6.5.1",
+        "@lezer/highlight": "^1.1.4"
+      },
+      "workspaces": {
+        "packages": [
+          "preview-themes"
+        ]
+      }
+    },
+    "node_modules/@bpmn-io/diagram-js-ui": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
+      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "htm": "^3.1.1",
+        "preact": "^10.11.2"
+      }
+    },
+    "node_modules/@bpmn-io/element-templates-validator": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.20.1.tgz",
+      "integrity": "sha512-kzlgjzxq1dYVkBzuGrDjU/lXF0s7AfafATy7TglamnPZtbwYuHgpeuM0qPBKRWmtTHccpDbrtQxbUmJWCBTz6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@camunda/element-templates-json-schema": "^0.21.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.39.1",
+        "json-source-map": "^0.6.1",
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/@bpmn-io/extract-process-variables": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-2.2.1.tgz",
+      "integrity": "sha512-1E5ydNzTqgx513NxA1nxk2CqDb9OkusfU9Tf6WejD1BiY+5u130XnZOFE/FQX0JB6ZmPOeFMx4IDEuHjrGhOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/@bpmn-io/feel-editor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.2.tgz",
+      "integrity": "sha512-pxbhUDAlLe+zDAvmG7Y057o8rnVImKYEbgjH4+zZiq3WjPw5bZYu2kraJfpWMs3xkyOCvLR6H3J3f8yJRuHmgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/lang-feel": "^3.0.0",
+        "@camunda/feel-builtins": "^1.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.13",
+        "@lezer/highlight": "^1.2.3",
+        "min-dom": "^5.2.0",
+        "mitt": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.1.0.tgz",
+      "integrity": "sha512-nOCYWMXgwR0joU4XKhu4f3P5f4/AsmuyiV1e+fzcXTCh7iMLU8VYdHXSIzZuJ0zxz3Gsnp7A8S8lt+HJ43H6IA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/language": "^6.12.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/feelin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelin/-/feelin-6.1.0.tgz",
+      "integrity": "sha512-nqmmlHRD9tl0ZcpYTEkZdpc/rAMoYc+ct0SOg9fFIFWRaEApme3DuXC7v9AMA5g+upGCKd6cUc3t97y+unpfMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@lezer/common": "^1.5.0",
+        "luxon": "^3.7.2",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
+      "integrity": "sha512-t/k0z5AW18J7Qz2i/bIFAlvlcS63RuyQB9OQ0YiC1WyMosxXRAnv98LHnVbwirx9vje1DLll85tkBT2B8KLjmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/language": "^6.11.3",
+        "@lezer/common": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lezer-feel": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.3.1.tgz",
+      "integrity": "sha512-MNe3M7XUuUk0OvrIIXM0m7M2hNLouxPqJyqd6+XCDMy9dsan0zLA0vl7Cu8ypCbsAlViIGIvYdkjzZNiXd3gng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.8",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/moddle-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.3.0.tgz",
+      "integrity": "sha512-0kz2PKfjIH3XFtO9Koxh7jV8e1DWWs4rgp0IczhJgluoRHf9Jhq8zX1H3wGJu6+lpg1Rkzc6YW1ezKz+2K8wTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/@bpmn-io/properties-panel": {
+      "version": "3.40.6",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.40.6.tgz",
+      "integrity": "sha512-lviXOp3z99BmdOoTazW13M6s4CyuCveygHL4g8v1z6Tp6rar4irBS//DggNLWha26Ae6vUfvHPnwcNjuHsNDjg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/feel-editor": "^2.5.2",
+        "@carbon/icons": "^11.69.0",
+        "@codemirror/view": "^6.28.1",
+        "classnames": "^2.5.1",
+        "feelers": "^1.5.1",
+        "focus-trap": "^8.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@camunda/element-templates-json-schema": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.21.0.tgz",
+      "integrity": "sha512-3O5oovVIsCrU0tG+WMm6rcmtiGM7tYni/H+oPN1EqLG1B3HPcRiLwypNrHz1w6aQy6vnjB8ovzSJ42taapqN/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@camunda/feel-builtins": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.1.0.tgz",
+      "integrity": "sha512-aBIGrXkURxDxBulrkaF1AOV261RSyukA5UWGRgDiULvlJ+P6/dYX7boBuO8Be9OP/hjAjZoTbK1kKcuqfCp7ng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@camunda/zeebe-element-templates-json-schema": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.2.tgz",
+      "integrity": "sha512-Cp5gS9vTw3/nZl+2sQ3EU6832rZeimSwXb6CObq0RGW6cX7hfiM57z6yuLRmMbSmHyrQdokE0CLSZ8gfU2feSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@carbon/icons": {
+      "version": "11.78.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.78.0.tgz",
+      "integrity": "sha512-EWqJbFSSpV0UTc8/9SiTzPcEcqmryKwospDyzC0+nFIrCtlZPFuma2jpdoiJ87TMCx/Bm1pD5lGqucxuMZkwnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -728,6 +935,17 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ibm/telemetry-js": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.11.0.tgz",
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "ibmtelemetry": "dist/collect.js"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -795,6 +1013,56 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -855,6 +1123,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -918,6 +1196,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-move": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
+      "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -1035,15 +1327,145 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bpmn-js": {
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.14.0.tgz",
+      "integrity": "sha512-z4CjyvK2wtP+IIunQJpZK1g5Xkfa089rueB2MCY2+NeZFz2RaHn17qJcXOvOhXvLHbUo+ldiXnkFuiGqslxIbQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
+      "dependencies": {
+        "bpmn-moddle": "^10.0.0",
+        "diagram-js": "^15.11.0",
+        "diagram-js-direct-editing": "^3.3.0",
+        "ids": "^3.0.2",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "tiny-svg": "^4.1.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bpmn-js-element-templates": {
-      "resolved": "../bpmn-js-element-templates",
-      "link": true
+      "version": "2.23.0",
+      "resolved": "git+ssh://git@github.com/vringar/bpmn-js-element-templates.git#aa9e6c9dd0bb17fbebea99392d8264c2d6c6cf14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/element-templates-validator": "^2.20.1",
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "bpmnlint": "^11.12.0",
+        "classnames": "^2.5.1",
+        "ids": "^3.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "preact-markup": "^2.1.1",
+        "semver": "^7.7.4",
+        "semver-compare": "^1.0.0",
+        "uuid": "^13.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">= 2.2",
+        "bpmn-js": ">= 11.5",
+        "bpmn-js-properties-panel": ">= 2",
+        "camunda-bpmn-js-behaviors": ">= 1.2.1",
+        "diagram-js": ">= 11.9"
+      }
+    },
+    "node_modules/bpmn-js-element-templates/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/bpmn-js-headless": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-headless/-/bpmn-js-headless-0.1.0.tgz",
       "integrity": "sha512-AdYHuEyxpLafJpWyUzak2/+rjqDZyk2l3EU186R/3W21x66dpeyPCAxt8n12TliQNudM9EZNzMmto79HNz715A==",
       "dev": true
+    },
+    "node_modules/bpmn-js-properties-panel": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.53.0.tgz",
+      "integrity": "sha512-fXn9yU6YLgr5SiaGHegAHZQe1jbezFPyqzZvTrTR1zOEmlNdTK4H9MAHFeBX6iasw31M9Y6KbPPP/tiZ/VhYug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "array-move": "^4.0.0",
+        "ids": "^3.0.1",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">= 3.40",
+        "bpmn-js": ">= 11.5",
+        "camunda-bpmn-js-behaviors": ">= 0.4",
+        "diagram-js": ">= 11.9"
+      }
+    },
+    "node_modules/bpmn-moddle": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "moddle": "^8.0.0",
+        "moddle-xml": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
+    "node_modules/bpmnlint": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.12.0.tgz",
+      "integrity": "sha512-c8zXfG2YH3U06u1+T1uSkcd82ict27G2z7gAK5toJnfwIlhwCKCy0GxeqCk4z/reuk3Ja//x7Z04IKwNpn1sNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/moddle-utils": "^0.3.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^10.0.0",
+        "bpmnlint-utils": "^1.1.1",
+        "cli-table": "^0.3.11",
+        "color-support": "^1.1.3",
+        "min-dash": "^5.0.0",
+        "mri": "^1.2.0",
+        "pluralize": "^8.0.0",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "bpmnlint": "bin/bpmnlint.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/bpmnlint-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
+      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1101,6 +1523,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/camunda-bpmn-js-behaviors": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.14.1.tgz",
+      "integrity": "sha512-M+awrL4PuKFi8kemtjLV8A32zODVQ2/cLuaHl2lZt5EKmMjxGb41BL3ulDRaK1Je712/zFTliYKNDX3IsLAvpQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ids": "^3.0.1",
+        "min-dash": "^5.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 9",
+        "camunda-bpmn-moddle": ">= 7",
+        "zeebe-bpmn-moddle": ">= 0.18"
+      }
+    },
+    "node_modules/camunda-bpmn-moddle": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
+      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.1",
@@ -1170,6 +1617,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1219,6 +1685,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1237,11 +1714,39 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1378,6 +1883,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/diagram-js": {
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.11.0.tgz",
+      "integrity": "sha512-BpKCKlyTZ4x4aOwAOBMns2jYiaajEUXqy9IzNQk2WyIaI3hECI8rCTBSxg9A9l8Kq7C4mCUvovULSRZ7G8vpyA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "clsx": "^2.1.1",
+        "didi": "^11.0.0",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "object-refs": "^0.4.0",
+        "path-intersection": "^4.1.0",
+        "tiny-svg": "^4.1.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/diagram-js-direct-editing": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
+      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "diagram-js": "*"
+      }
+    },
+    "node_modules/didi": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
+      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -1386,6 +1942,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/domify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1951,6 +2520,39 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/feelers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
+      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/feelin": "^6.1.0",
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "workspaces": {
+        "packages": [
+          "feelers-playground"
+        ]
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2006,6 +2608,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
+      "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -2199,6 +2812,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -2301,6 +2928,24 @@
         "he": "bin/he"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2336,6 +2981,14 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits-browser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -2786,6 +3439,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -2884,6 +3544,35 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/min-dash": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/min-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domify": "^3.0.0",
+        "min-dash": "^5.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2904,6 +3593,14 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mocha": {
       "version": "11.5.0",
@@ -2967,6 +3664,43 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/moddle": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz",
+      "integrity": "sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/moddle-xml": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
+      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "saxen": "^11.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "moddle": ">= 6.2.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3007,6 +3741,17 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-refs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object.assign": {
@@ -3151,6 +3896,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-intersection": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
+      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.20"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3189,6 +3945,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -3196,6 +3962,28 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-markup": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
+      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -3394,6 +4182,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxen": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
+      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3402,6 +4200,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -3646,6 +4451,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3671,6 +4484,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/tiny-svg": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
+      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/type-check": {
@@ -3794,6 +4637,28 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4075,6 +4940,251 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@bpmn-io/cm-theme": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/language": "^6.3.1",
+        "@codemirror/view": "^6.5.1",
+        "@lezer/highlight": "^1.1.4"
+      }
+    },
+    "@bpmn-io/diagram-js-ui": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
+      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "htm": "^3.1.1",
+        "preact": "^10.11.2"
+      }
+    },
+    "@bpmn-io/element-templates-validator": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.20.1.tgz",
+      "integrity": "sha512-kzlgjzxq1dYVkBzuGrDjU/lXF0s7AfafATy7TglamnPZtbwYuHgpeuM0qPBKRWmtTHccpDbrtQxbUmJWCBTz6w==",
+      "dev": true,
+      "requires": {
+        "@camunda/element-templates-json-schema": "^0.21.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.39.1",
+        "json-source-map": "^0.6.1",
+        "min-dash": "^5.0.0"
+      }
+    },
+    "@bpmn-io/extract-process-variables": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-2.2.1.tgz",
+      "integrity": "sha512-1E5ydNzTqgx513NxA1nxk2CqDb9OkusfU9Tf6WejD1BiY+5u130XnZOFE/FQX0JB6ZmPOeFMx4IDEuHjrGhOzw==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "@bpmn-io/feel-editor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.2.tgz",
+      "integrity": "sha512-pxbhUDAlLe+zDAvmG7Y057o8rnVImKYEbgjH4+zZiq3WjPw5bZYu2kraJfpWMs3xkyOCvLR6H3J3f8yJRuHmgw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/lang-feel": "^3.0.0",
+        "@camunda/feel-builtins": "^1.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.13",
+        "@lezer/highlight": "^1.2.3",
+        "min-dom": "^5.2.0",
+        "mitt": "^3.0.1"
+      }
+    },
+    "@bpmn-io/feel-lint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.1.0.tgz",
+      "integrity": "sha512-nOCYWMXgwR0joU4XKhu4f3P5f4/AsmuyiV1e+fzcXTCh7iMLU8VYdHXSIzZuJ0zxz3Gsnp7A8S8lt+HJ43H6IA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/language": "^6.12.1"
+      }
+    },
+    "@bpmn-io/feelin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelin/-/feelin-6.1.0.tgz",
+      "integrity": "sha512-nqmmlHRD9tl0ZcpYTEkZdpc/rAMoYc+ct0SOg9fFIFWRaEApme3DuXC7v9AMA5g+upGCKd6cUc3t97y+unpfMw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@lezer/common": "^1.5.0",
+        "luxon": "^3.7.2",
+        "min-dash": "^5.0.0"
+      }
+    },
+    "@bpmn-io/lang-feel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
+      "integrity": "sha512-t/k0z5AW18J7Qz2i/bIFAlvlcS63RuyQB9OQ0YiC1WyMosxXRAnv98LHnVbwirx9vje1DLll85tkBT2B8KLjmQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/lezer-feel": "^2.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/language": "^6.11.3",
+        "@lezer/common": "^1.4.0"
+      }
+    },
+    "@bpmn-io/lezer-feel": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.3.1.tgz",
+      "integrity": "sha512-MNe3M7XUuUk0OvrIIXM0m7M2hNLouxPqJyqd6+XCDMy9dsan0zLA0vl7Cu8ypCbsAlViIGIvYdkjzZNiXd3gng==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.8",
+        "min-dash": "^5.0.0"
+      }
+    },
+    "@bpmn-io/moddle-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.3.0.tgz",
+      "integrity": "sha512-0kz2PKfjIH3XFtO9Koxh7jV8e1DWWs4rgp0IczhJgluoRHf9Jhq8zX1H3wGJu6+lpg1Rkzc6YW1ezKz+2K8wTg==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "@bpmn-io/properties-panel": {
+      "version": "3.40.6",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.40.6.tgz",
+      "integrity": "sha512-lviXOp3z99BmdOoTazW13M6s4CyuCveygHL4g8v1z6Tp6rar4irBS//DggNLWha26Ae6vUfvHPnwcNjuHsNDjg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/feel-editor": "^2.5.2",
+        "@carbon/icons": "^11.69.0",
+        "@codemirror/view": "^6.28.1",
+        "classnames": "^2.5.1",
+        "feelers": "^1.5.1",
+        "focus-trap": "^8.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      }
+    },
+    "@camunda/element-templates-json-schema": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.21.0.tgz",
+      "integrity": "sha512-3O5oovVIsCrU0tG+WMm6rcmtiGM7tYni/H+oPN1EqLG1B3HPcRiLwypNrHz1w6aQy6vnjB8ovzSJ42taapqN/w==",
+      "dev": true
+    },
+    "@camunda/feel-builtins": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.1.0.tgz",
+      "integrity": "sha512-aBIGrXkURxDxBulrkaF1AOV261RSyukA5UWGRgDiULvlJ+P6/dYX7boBuO8Be9OP/hjAjZoTbK1kKcuqfCp7ng==",
+      "dev": true,
+      "peer": true
+    },
+    "@camunda/zeebe-element-templates-json-schema": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.2.tgz",
+      "integrity": "sha512-Cp5gS9vTw3/nZl+2sQ3EU6832rZeimSwXb6CObq0RGW6cX7hfiM57z6yuLRmMbSmHyrQdokE0CLSZ8gfU2feSg==",
+      "dev": true
+    },
+    "@carbon/icons": {
+      "version": "11.78.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.78.0.tgz",
+      "integrity": "sha512-EWqJbFSSpV0UTc8/9SiTzPcEcqmryKwospDyzC0+nFIrCtlZPFuma2jpdoiJ87TMCx/Bm1pD5lGqucxuMZkwnQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -4367,6 +5477,13 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true
     },
+    "@ibm/telemetry-js": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.11.0.tgz",
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "dev": true,
+      "peer": true
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4415,6 +5532,51 @@
         }
       }
     },
+    "@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "peer": true
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4459,6 +5621,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4500,6 +5668,13 @@
         "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       }
+    },
+    "array-move": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
+      "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
+      "dev": true,
+      "peer": true
     },
     "array.prototype.findlast": {
       "version": "1.2.5",
@@ -4583,79 +5758,102 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bpmn-js-element-templates": {
-      "version": "file:../bpmn-js-element-templates",
+    "bpmn-js": {
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.14.0.tgz",
+      "integrity": "sha512-z4CjyvK2wtP+IIunQJpZK1g5Xkfa089rueB2MCY2+NeZFz2RaHn17qJcXOvOhXvLHbUo+ldiXnkFuiGqslxIbQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@babel/core": "^7.28.5",
-        "@babel/plugin-transform-react-jsx": "^7.27.1",
-        "@bpmn-io/element-template-chooser": "^2.1.0",
-        "@bpmn-io/element-template-icon-renderer": "^1.0.0",
+        "bpmn-moddle": "^10.0.0",
+        "diagram-js": "^15.11.0",
+        "diagram-js-direct-editing": "^3.3.0",
+        "ids": "^3.0.2",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "tiny-svg": "^4.1.4"
+      }
+    },
+    "bpmn-js-element-templates": {
+      "version": "git+ssh://git@github.com/vringar/bpmn-js-element-templates.git#aa9e6c9dd0bb17fbebea99392d8264c2d6c6cf14",
+      "dev": true,
+      "from": "bpmn-js-element-templates@github:vringar/bpmn-js-element-templates#feat/export-util-subpath",
+      "requires": {
         "@bpmn-io/element-templates-validator": "^2.20.1",
         "@bpmn-io/extract-process-variables": "^2.2.1",
-        "@bpmn-io/properties-panel": "^3.40.2",
-        "@bpmn-io/variable-resolver": "^2.0.0",
-        "@camunda/linting": "^3.48.1",
-        "@rollup/plugin-alias": "^6.0.0",
-        "@rollup/plugin-babel": "^7.0.0",
-        "@rollup/plugin-commonjs": "^29.0.0",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^16.0.3",
-        "@rollup/plugin-replace": "^6.0.3",
-        "@testing-library/preact": "^2.0.1",
-        "@testing-library/preact-hooks": "^1.1.0",
-        "assert": "^2.1.0",
-        "babel-loader": "^10.0.0",
-        "babel-plugin-istanbul": "^7.0.1",
-        "bpmn-js": "^18.14.0",
-        "bpmn-js-create-append-anything": "^1.2.0",
-        "bpmn-js-properties-panel": "^5.52.1",
-        "bpmn-moddle": "^10.0.0",
         "bpmnlint": "^11.12.0",
-        "camunda-bpmn-js-behaviors": "^1.14.1",
-        "camunda-bpmn-moddle": "^7.0.1",
-        "chai": "^6.2.2",
         "classnames": "^2.5.1",
-        "copy-webpack-plugin": "^14.0.0",
-        "cross-env": "^10.0.0",
-        "diagram-js": "^15.11.0",
-        "downloadjs": "^1.4.7",
-        "eslint": "^9.39.2",
-        "eslint-plugin-bpmn-io": "^2.2.0",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "file-drops": "^0.7.0",
         "ids": "^3.0.0",
-        "karma": "^6.4.4",
-        "karma-chrome-launcher-2": "^3.3.0",
-        "karma-coverage": "^2.2.1",
-        "karma-debug-launcher": "^0.0.5",
-        "karma-env-preprocessor": "^0.1.1",
-        "karma-mocha": "^2.0.1",
-        "karma-webpack": "^5.0.1",
         "min-dash": "^5.0.0",
         "min-dom": "^5.3.0",
-        "mocha": "^11.0.0",
-        "mocha-test-container-support": "^0.2.0",
-        "modeler-moddle": "^0.2.0",
-        "npm-run-all2": "^8.0.4",
         "preact-markup": "^2.1.1",
-        "puppeteer": "^24.34.0",
-        "raw-loader": "^4.0.2",
-        "rollup": "^4.57.1",
-        "rollup-plugin-copy": "^3.5.0",
         "semver": "^7.7.4",
         "semver-compare": "^1.0.0",
-        "sinon": "^21.0.0",
-        "sinon-chai": "^4.0.0",
-        "uuid": "^13.0.0",
-        "webpack": "^5.105.3",
-        "zeebe-bpmn-moddle": "^1.12.0"
+        "uuid": "^13.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "dev": true
+        }
       }
     },
     "bpmn-js-headless": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-headless/-/bpmn-js-headless-0.1.0.tgz",
       "integrity": "sha512-AdYHuEyxpLafJpWyUzak2/+rjqDZyk2l3EU186R/3W21x66dpeyPCAxt8n12TliQNudM9EZNzMmto79HNz715A==",
+      "dev": true
+    },
+    "bpmn-js-properties-panel": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.53.0.tgz",
+      "integrity": "sha512-fXn9yU6YLgr5SiaGHegAHZQe1jbezFPyqzZvTrTR1zOEmlNdTK4H9MAHFeBX6iasw31M9Y6KbPPP/tiZ/VhYug==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "array-move": "^4.0.0",
+        "ids": "^3.0.1",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0"
+      }
+    },
+    "bpmn-moddle": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^5.0.0",
+        "moddle": "^8.0.0",
+        "moddle-xml": "^12.0.0"
+      }
+    },
+    "bpmnlint": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.12.0.tgz",
+      "integrity": "sha512-c8zXfG2YH3U06u1+T1uSkcd82ict27G2z7gAK5toJnfwIlhwCKCy0GxeqCk4z/reuk3Ja//x7Z04IKwNpn1sNQ==",
+      "dev": true,
+      "requires": {
+        "@bpmn-io/moddle-utils": "^0.3.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^10.0.0",
+        "bpmnlint-utils": "^1.1.1",
+        "cli-table": "^0.3.11",
+        "color-support": "^1.1.3",
+        "min-dash": "^5.0.0",
+        "mri": "^1.2.0",
+        "pluralize": "^8.0.0",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "bpmnlint-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
+      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
       "dev": true
     },
     "brace-expansion": {
@@ -4698,6 +5896,24 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
+    },
+    "camunda-bpmn-js-behaviors": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.14.1.tgz",
+      "integrity": "sha512-M+awrL4PuKFi8kemtjLV8A32zODVQ2/cLuaHl2lZt5EKmMjxGb41BL3ulDRaK1Je712/zFTliYKNDX3IsLAvpQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ids": "^3.0.1",
+        "min-dash": "^5.0.0"
+      }
+    },
+    "camunda-bpmn-moddle": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
+      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
+      "dev": true,
+      "peer": true
     },
     "chai": {
       "version": "6.2.1",
@@ -4744,6 +5960,21 @@
         "readdirp": "^4.0.1"
       }
     },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
     "cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4777,6 +6008,13 @@
         }
       }
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "peer": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4792,11 +6030,30 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "peer": true
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -4885,10 +6142,52 @@
         "object-keys": "^1.1.1"
       }
     },
+    "diagram-js": {
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.11.0.tgz",
+      "integrity": "sha512-BpKCKlyTZ4x4aOwAOBMns2jYiaajEUXqy9IzNQk2WyIaI3hECI8rCTBSxg9A9l8Kq7C4mCUvovULSRZ7G8vpyA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "clsx": "^2.1.1",
+        "didi": "^11.0.0",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "object-refs": "^0.4.0",
+        "path-intersection": "^4.1.0",
+        "tiny-svg": "^4.1.4"
+      }
+    },
+    "diagram-js-direct-editing": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
+      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      }
+    },
+    "didi": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
+      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
+      "dev": true,
+      "peer": true
+    },
     "diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true
+    },
+    "domify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==",
       "dev": true
     },
     "eastasianwidth": {
@@ -5308,6 +6607,30 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "feelers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
+      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/feelin": "^6.1.0",
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0"
+      }
+    },
     "file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5348,6 +6671,16 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "focus-trap": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
+      "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tabbable": "^6.4.0"
+      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -5481,6 +6814,18 @@
         "gopd": "^1.0.1"
       }
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5547,6 +6892,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true,
+      "peer": true
+    },
+    "ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==",
+      "dev": true
+    },
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5568,6 +6926,13 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
+    },
+    "inherits-browser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "dev": true,
+      "peer": true
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -5862,6 +7227,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "dev": true
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5939,6 +7310,29 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "peer": true
+    },
+    "min-dash": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "dev": true
+    },
+    "min-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
+      "dev": true,
+      "requires": {
+        "domify": "^3.0.0",
+        "min-dash": "^5.0.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5953,6 +7347,13 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
+    },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "peer": true
     },
     "mocha": {
       "version": "11.5.0",
@@ -6002,6 +7403,31 @@
         }
       }
     },
+    "moddle": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz",
+      "integrity": "sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "moddle-xml": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
+      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^5.0.0",
+        "saxen": "^11.0.2"
+      }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6031,6 +7457,13 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-refs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "dev": true,
+      "peer": true
     },
     "object.assign": {
       "version": "4.1.5",
@@ -6131,6 +7564,13 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
+    "path-intersection": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
+      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
+      "dev": true,
+      "peer": true
+    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6159,11 +7599,31 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true
+    },
+    "preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "peer": true
+    },
+    "preact-markup": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
+      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
+      "dev": true,
+      "requires": {}
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -6294,10 +7754,22 @@
         "is-regex": "^1.1.4"
       }
     },
+    "saxen": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
+      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==",
+      "dev": true
+    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
     },
     "serialize-javascript": {
@@ -6478,6 +7950,13 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "peer": true
+    },
     "supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -6492,6 +7971,30 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "peer": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "tiny-svg": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
+      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
+      "dev": true,
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -6580,6 +8083,19 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true
+    },
+    "w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "peer": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "all": "npm run lint && npm run build && npm run test",
-    "build": "esbuild src/index.js --bundle --format=esm --outfile=dist/index.js",
+    "build": "esbuild src/index.js --bundle --format=esm --platform=node --outfile=dist/index.js",
     "lint": "eslint .",
     "test": "mocha --timeout=10000",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "type": "module",
   "files": [
     "bin",
-    "dist",
-    "index.js"
+    "dist"
   ],
   "scripts": {
     "all": "npm run lint && npm run build && npm run test",
@@ -30,7 +29,7 @@
   },
   "homepage": "https://github.com/bpmn-io/element-templates-cli#readme",
   "devDependencies": {
-    "bpmn-js-element-templates": "^2.12.0",
+    "bpmn-js-element-templates": "file:../bpmn-js-element-templates",
     "bpmn-js-headless": "^0.1.0",
     "chai": "^6.0.0",
     "esbuild": "^0.25.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/bpmn-io/element-templates-cli#readme",
   "devDependencies": {
-    "bpmn-js-element-templates": "file:../bpmn-js-element-templates",
+    "bpmn-js-element-templates": "github:vringar/bpmn-js-element-templates#feat/export-util-subpath",
     "bpmn-js-headless": "^0.1.0",
     "chai": "^6.0.0",
     "esbuild": "^0.25.5",

--- a/src/applyTemplate.js
+++ b/src/applyTemplate.js
@@ -1,51 +1,13 @@
-import Modeler from 'bpmn-js-headless/lib/Modeler';
-import ZeebeModdleExtension from 'zeebe-bpmn-moddle/resources/zeebe.json';
-import { CloudElementTemplatesCoreModule } from 'bpmn-js-element-templates/core';
+import { createModeler, getElement, applyTemplateToElement, exportDiagram } from './modeler.js';
 
 export async function applyTemplate(diagram, template, element) {
   const parsedTemplate = JSON.parse(template);
 
-  const modeler = await importDiagram(diagram);
+  const modeler = await createModeler(diagram);
   const el = getElement(modeler, element);
   applyTemplateToElement(modeler, el, parsedTemplate);
 
   const xml = await exportDiagram(modeler);
 
   return xml;
-}
-
-async function importDiagram(diagram) {
-  const modeler = new Modeler({
-    additionalModules: [
-      CloudElementTemplatesCoreModule
-    ],
-    moddleExtensions: {
-      zeebe: ZeebeModdleExtension
-    }
-  });
-
-  await modeler.importXML(diagram);
-
-  return modeler;
-}
-
-async function exportDiagram(modeler) {
-  const result = await modeler.saveXML({
-    format: true
-  });
-
-  return result.xml;
-}
-
-function getElement(modeler, element) {
-  const elementRegistry = modeler.get('elementRegistry');
-
-  return elementRegistry.get(element);
-}
-
-function applyTemplateToElement(modeler, element, template) {
-  const elementTemplates = modeler.get('elementTemplates');
-  elementTemplates.set([ template ]);
-
-  elementTemplates.applyTemplate(element, template);
 }

--- a/src/downloadTemplate.js
+++ b/src/downloadTemplate.js
@@ -1,0 +1,82 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { getCliCacheDir } from './resolveTemplate.js';
+
+const MARKETPLACE_URL = 'https://marketplace.cloud.camunda.io/api/v1/ootb-connectors';
+
+/**
+ * Download a specific template version from the marketplace index and save it
+ * to the local CLI cache.
+ *
+ * The marketplace index format is: { [id]: [{ version, ref, engine }] }
+ *
+ * @param {string} id         Template ID to download
+ * @param {object} [options]
+ * @param {number} [options.version]       Specific version to download; defaults to latest
+ * @param {string} [options.cacheDir]
+ * @param {string} [options.marketplaceUrl]
+ * @param {Function} [options.fetchFn]
+ * @returns {Promise<{ id: string, version: number|undefined, file: string }>}
+ */
+export async function downloadTemplate(id, options = {}) {
+  const {
+    version,
+    cacheDir = getCliCacheDir(),
+    marketplaceUrl = MARKETPLACE_URL,
+    fetchFn = fetch
+  } = options;
+
+  const indexResponse = await fetchFn(marketplaceUrl);
+  if (!indexResponse.ok) {
+    throw new Error(
+      `Failed to fetch marketplace index (HTTP ${indexResponse.status})`
+    );
+  }
+
+  const index = await indexResponse.json();
+  const entries = index[id];
+
+  if (!entries || entries.length === 0) {
+    throw new Error(
+      `Template "${id}" not found in marketplace. Check the ID and try again.`
+    );
+  }
+
+  let entry;
+  if (version !== undefined) {
+    entry = entries.find(e => e.version === version);
+    if (!entry) {
+      const available = entries.map(e => e.version).sort((a, b) => b - a).join(', ');
+      throw new Error(
+        `Version ${version} of "${id}" not found in marketplace. Available: ${available}`
+      );
+    }
+  } else {
+    entry = entries.reduce((a, b) => (a.version >= b.version ? a : b));
+  }
+
+  const templateResponse = await fetchFn(entry.ref);
+  if (!templateResponse.ok) {
+    throw new Error(
+      `Failed to fetch template "${id}" v${entry.version} from ${entry.ref} (HTTP ${templateResponse.status})`
+    );
+  }
+
+  const templateText = await templateResponse.text();
+
+  const templatesDir = path.join(cacheDir, 'templates');
+  await mkdir(templatesDir, { recursive: true });
+
+  const filename = sanitizeFilename(id) +
+    (entry.version !== undefined ? `_v${entry.version}` : '') +
+    '.json';
+  const filePath = path.join(templatesDir, filename);
+  await writeFile(filePath, templateText);
+
+  return { id, version: entry.version, file: filePath };
+}
+
+function sanitizeFilename(id) {
+  return id.replace(/[^a-zA-Z0-9._-]/g, '_');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
 export { applyTemplate } from './applyTemplate.js';
+export { queryFields } from './queryFields.js';
+export { setFields } from './setFields.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
 export { applyTemplate } from './applyTemplate.js';
 export { queryFields } from './queryFields.js';
 export { setFields } from './setFields.js';
+export { resolveTemplatePath, resolveTemplateId } from './resolveTemplate.js';
+export { listTemplates } from './listTemplates.js';
+export { downloadTemplate } from './downloadTemplate.js';

--- a/src/listTemplates.js
+++ b/src/listTemplates.js
@@ -1,0 +1,124 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { getCliCacheDir, getModelerUserDataDir } from './resolveTemplate.js';
+
+/**
+ * @typedef {{ id: string, name: string, version: number|undefined, source: string }} TemplateEntry
+ */
+
+/**
+ * List all template entries found across all standard search dirs.
+ *
+ * @param {object} [options]
+ * @param {string} [options.cacheDir]
+ * @param {string} [options.modelerDir]
+ * @param {string} [options.diagramPath]   When provided, also walks up .camunda dirs
+ * @returns {Promise<TemplateEntry[]>}
+ */
+export async function listTemplates(options = {}) {
+  const {
+    cacheDir = getCliCacheDir(),
+    modelerDir = getModelerUserDataDir(),
+    diagramPath
+  } = options;
+
+  const searchDirs = [];
+
+  if (diagramPath) {
+    searchDirs.push(...walkUpCamundaDirs(path.dirname(path.resolve(diagramPath))));
+  }
+
+  if (modelerDir) {
+    searchDirs.push({
+      dir: path.join(modelerDir, 'resources', 'element-templates'),
+      label: 'modeler'
+    });
+  }
+
+  searchDirs.push({
+    dir: path.join(cacheDir, 'templates'),
+    label: 'cache'
+  });
+
+  const seen = new Map(); // id -> TemplateEntry[]
+  const allEntries = [];
+
+  for (const { dir, label } of searchDirs) {
+    const entries = await scanDir(dir, label);
+    for (const entry of entries) {
+      allEntries.push(entry);
+      if (!seen.has(entry.id)) {
+        seen.set(entry.id, []);
+      }
+      seen.get(entry.id).push(entry);
+    }
+  }
+
+  return allEntries;
+}
+
+function walkUpCamundaDirs(startDir) {
+  const dirs = [];
+  let current = startDir;
+  let parent = path.dirname(current);
+
+  dirs.push({
+    dir: path.join(current, '.camunda', 'element-templates'),
+    label: path.join(current, '.camunda', 'element-templates')
+  });
+
+  while (parent !== current) {
+    current = parent;
+    parent = path.dirname(current);
+    dirs.push({
+      dir: path.join(current, '.camunda', 'element-templates'),
+      label: path.join(current, '.camunda', 'element-templates')
+    });
+  }
+
+  return dirs;
+}
+
+async function scanDir(dir, label) {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  let entries;
+  try {
+    entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+
+    const filePath = path.join(entry.parentPath || dir, entry.name);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    const templates = Array.isArray(parsed) ? parsed : [ parsed ];
+
+    for (const template of templates) {
+      if (!template?.id) continue;
+      results.push({
+        id: template.id,
+        name: template.name ?? template.id,
+        version: template.version,
+        source: label
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/modeler.js
+++ b/src/modeler.js
@@ -1,0 +1,44 @@
+import Modeler from 'bpmn-js-headless/lib/Modeler';
+import ZeebeModdleExtension from 'zeebe-bpmn-moddle/resources/zeebe.json';
+import { CloudElementTemplatesCoreModule } from 'bpmn-js-element-templates/core';
+
+export async function createModeler(diagram) {
+  const modeler = new Modeler({
+    additionalModules: [
+      CloudElementTemplatesCoreModule
+    ],
+    moddleExtensions: {
+      zeebe: ZeebeModdleExtension
+    }
+  });
+
+  await modeler.importXML(diagram);
+
+  return modeler;
+}
+
+export function getElement(modeler, elementId) {
+  const elementRegistry = modeler.get('elementRegistry');
+  const element = elementRegistry.get(elementId);
+
+  if (!element) {
+    throw new Error(`Element "${ elementId }" not found in diagram`);
+  }
+
+  return element;
+}
+
+export function applyTemplateToElement(modeler, element, template) {
+  const elementTemplates = modeler.get('elementTemplates');
+  elementTemplates.set([ template ]);
+
+  elementTemplates.applyTemplate(element, template);
+}
+
+export async function exportDiagram(modeler) {
+  const result = await modeler.saveXML({
+    format: true
+  });
+
+  return result.xml;
+}

--- a/src/queryFields.js
+++ b/src/queryFields.js
@@ -1,0 +1,77 @@
+import {
+  getPropertyValue,
+  applyConditions
+} from 'bpmn-js-element-templates/util';
+
+import { createModeler, getElement, applyTemplateToElement } from './modeler.js';
+
+const DEFAULT_GROUP = 'General';
+
+export async function queryFields(diagram, template, elementId) {
+  const parsedTemplate = JSON.parse(template);
+
+  const modeler = await createModeler(diagram);
+  const element = getElement(modeler, elementId);
+  applyTemplateToElement(modeler, element, parsedTemplate);
+
+  // Filter to visible properties (conditions evaluated)
+  const filtered = applyConditions(element, parsedTemplate);
+  const visibleProps = filtered.properties.filter(p => p.type !== 'Hidden' && p.label);
+
+  // Build groups lookup: group id -> group label
+  const groupsMap = {};
+  for (const group of (parsedTemplate.groups || [])) {
+    groupsMap[group.id] = group.label;
+  }
+
+  // Build output organized by sections
+  const result = {};
+
+  for (const prop of visibleProps) {
+    const sectionName = prop.group
+      ? (groupsMap[prop.group] || prop.group)
+      : DEFAULT_GROUP;
+
+    if (!result[sectionName]) {
+      result[sectionName] = {};
+    }
+
+    const entry = {
+      value: getPropertyValue(element, prop),
+      type: prop.type
+    };
+
+    if (prop.description) {
+      entry.description = prop.description;
+    }
+
+    if (prop.type === 'Dropdown' && prop.choices) {
+      entry.choices = prop.choices;
+    }
+
+    if (prop.feel) {
+      entry.feel = prop.feel;
+    }
+
+    if (prop.constraints) {
+      entry.constraints = prop.constraints;
+    }
+
+    // Disambiguate duplicate labels within the same section
+    let label = prop.label;
+
+    if (result[sectionName][label]) {
+      let suffix = 2;
+
+      while (result[sectionName][`${ label } (${ suffix })`]) {
+        suffix++;
+      }
+
+      label = `${ label } (${ suffix })`;
+    }
+
+    result[sectionName][label] = entry;
+  }
+
+  return result;
+}

--- a/src/resolveTemplate.js
+++ b/src/resolveTemplate.js
@@ -1,0 +1,166 @@
+import { readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const MARKETPLACE_URL = 'https://marketplace.cloud.camunda.io/api/v1/ootb-connectors';
+
+export async function resolveTemplatePath(templatePath) {
+  return readFile(templatePath, 'utf8');
+}
+
+export async function resolveTemplateId(id, options = {}) {
+  const {
+    diagramPath,
+    cacheDir = getCliCacheDir(),
+    modelerDir = getModelerUserDataDir(),
+    marketplaceUrl = MARKETPLACE_URL,
+    fetchFn = fetch
+  } = options;
+
+  const searchDirs = [];
+
+  if (diagramPath) {
+    searchDirs.push(...walkUpCamundaDirs(path.dirname(path.resolve(diagramPath))));
+  }
+
+  if (modelerDir) {
+    searchDirs.push(path.join(modelerDir, 'resources', 'element-templates'));
+  }
+
+  searchDirs.push(path.join(cacheDir, 'templates'));
+
+  for (const dir of searchDirs) {
+    const found = await findTemplateInDir(dir, id);
+    if (found) {
+      return found;
+    }
+  }
+
+  return fetchAndCache(id, cacheDir, marketplaceUrl, fetchFn);
+}
+
+function walkUpCamundaDirs(startDir) {
+  const dirs = [];
+  let current = startDir;
+  let parent = path.dirname(current);
+
+  dirs.push(path.join(current, '.camunda', 'element-templates'));
+  while (parent !== current) {
+    current = parent;
+    parent = path.dirname(current);
+    dirs.push(path.join(current, '.camunda', 'element-templates'));
+  }
+
+  return dirs;
+}
+
+async function findTemplateInDir(dir, id) {
+  if (!existsSync(dir)) {
+    return null;
+  }
+
+  let entries;
+  try {
+    entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  let best = null;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+
+    const filePath = path.join(entry.parentPath || dir, entry.name);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    const templates = Array.isArray(parsed) ? parsed : [ parsed ];
+
+    for (const template of templates) {
+      if (template?.id === id) {
+        if (!best || (template.version ?? 0) > (best.template.version ?? 0)) {
+          best = { template, filePath };
+        }
+      }
+    }
+  }
+
+  return best ? JSON.stringify(best.template) : null;
+}
+
+async function fetchAndCache(id, cacheDir, marketplaceUrl, fetchFn) {
+  const indexResponse = await fetchFn(marketplaceUrl);
+  if (!indexResponse.ok) {
+    throw new Error(
+      `Failed to fetch marketplace index (HTTP ${indexResponse.status}). ` +
+      `Template "${id}" not found in local paths.`
+    );
+  }
+
+  const index = await indexResponse.json();
+  const versions = index[id];
+
+  if (!versions || versions.length === 0) {
+    throw new Error(
+      `Template "${id}" not found in local paths or marketplace. ` +
+      'Check the ID and try again.'
+    );
+  }
+
+  const latest = versions.reduce((a, b) => (a.version >= b.version ? a : b));
+
+  const templateResponse = await fetchFn(latest.ref);
+  if (!templateResponse.ok) {
+    throw new Error(
+      `Failed to fetch template "${id}" from ${latest.ref} (HTTP ${templateResponse.status})`
+    );
+  }
+
+  const templateText = await templateResponse.text();
+
+  const templatesDir = path.join(cacheDir, 'templates');
+  await mkdir(templatesDir, { recursive: true });
+
+  const filename = sanitizeFilename(id) + '.json';
+  await writeFile(path.join(templatesDir, filename), templateText);
+
+  return templateText;
+}
+
+function sanitizeFilename(id) {
+  return id.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export function getCliCacheDir() {
+  const xdg = process.env.XDG_CACHE_HOME;
+  if (xdg) {
+    return path.join(xdg, 'element-templates-cli');
+  }
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    return path.join(localAppData, 'element-templates-cli', 'Cache');
+  }
+  return path.join(os.homedir(), '.cache', 'element-templates-cli');
+}
+
+export function getModelerUserDataDir() {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return path.join(appData, 'camunda-modeler');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'camunda-modeler');
+  }
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg) {
+    return path.join(xdg, 'camunda-modeler');
+  }
+  return path.join(os.homedir(), '.config', 'camunda-modeler');
+}

--- a/src/setFields.js
+++ b/src/setFields.js
@@ -1,0 +1,149 @@
+import {
+  setPropertyValue,
+  validateProperty,
+  applyConditions
+} from 'bpmn-js-element-templates/util';
+
+import { createModeler, getElement, applyTemplateToElement, exportDiagram } from './modeler.js';
+
+export async function setFields(diagram, template, elementId, values) {
+  const parsedTemplate = JSON.parse(template);
+
+  const modeler = await createModeler(diagram);
+  const element = getElement(modeler, elementId);
+  applyTemplateToElement(modeler, element, parsedTemplate);
+
+  const bpmnFactory = modeler.get('bpmnFactory');
+  const commandStack = modeler.get('commandStack');
+
+  // Build groups lookup: group id -> group label
+  const groupsMap = {};
+  for (const group of (parsedTemplate.groups || [])) {
+    groupsMap[group.id] = group.label;
+  }
+
+  // Process values with cascading condition re-evaluation
+  const pendingKeys = new Set(Object.keys(values));
+  const maxIterations = pendingKeys.size + 1;
+  let iteration = 0;
+
+  while (pendingKeys.size > 0) {
+
+    if (++iteration > maxIterations) {
+      throw new Error(
+        'Maximum iteration limit reached during cascading condition evaluation. ' +
+        'This may indicate circular conditions in the template.'
+      );
+    }
+
+    const filtered = applyConditions(element, parsedTemplate);
+    const visibleProps = filtered.properties.filter(p => p.type !== 'Hidden' && p.label);
+
+    let progress = false;
+
+    for (const key of [ ...pendingKeys ]) {
+      const prop = resolveProperty(key, visibleProps, groupsMap);
+
+      if (!prop) {
+        continue;
+      }
+
+      const value = values[key];
+
+      // Validate against constraints
+      const error = validateProperty(value, prop);
+      if (error) {
+        throw new Error(`Validation failed for "${key}": ${error}`);
+      }
+
+      // Set the value on the BPMN model
+      setPropertyValue(bpmnFactory, commandStack, element, prop, value);
+
+      pendingKeys.delete(key);
+      progress = true;
+    }
+
+    if (!progress) {
+      const remaining = [ ...pendingKeys ].join(', ');
+      throw new Error(
+        `Could not resolve fields: ${remaining}. ` +
+        'They may not be visible given the current property values, ' +
+        'or the labels do not match any known property.'
+      );
+    }
+  }
+
+  return await exportDiagram(modeler);
+}
+
+function resolveProperty(key, visibleProps, groupsMap) {
+
+  // Check for disambiguation suffix pattern: "Label (N)"
+  const suffixMatch = key.match(/^(.+) \((\d+)\)$/);
+
+  if (suffixMatch) {
+    return resolveNthLabel(suffixMatch[1], parseInt(suffixMatch[2]), visibleProps, groupsMap);
+  }
+
+  // Try plain label match
+  const byLabel = visibleProps.filter(p => p.label === key);
+
+  if (byLabel.length === 1) {
+    return byLabel[0];
+  }
+
+  // Ambiguous plain label — require section qualification
+  if (byLabel.length > 1) {
+    throw new Error(
+      `Ambiguous label "${ key }" matches ${ byLabel.length } fields. ` +
+      'Use "Section.Label" format to disambiguate.'
+    );
+  }
+
+  // Try section-qualified: "Section.Label"
+  const dotIdx = key.indexOf('.');
+
+  if (dotIdx > 0) {
+    const section = key.slice(0, dotIdx);
+    const label = key.slice(dotIdx + 1);
+
+    return visibleProps.find(p => {
+      const sectionName = p.group
+        ? (groupsMap[p.group] || p.group)
+        : 'General';
+      return sectionName === section && p.label === label;
+    });
+  }
+
+  // Not found among visible props (may become visible after other changes)
+  return null;
+}
+
+/**
+ * Resolve the Nth occurrence of a label within a section,
+ * matching the disambiguation convention used by queryFields.
+ *
+ * @param {string} label - the base label (without suffix)
+ * @param {number} n - occurrence index (2 = second occurrence)
+ * @param {Array} visibleProps
+ * @param {Object} groupsMap
+ * @return {Object|null}
+ */
+function resolveNthLabel(label, n, visibleProps, groupsMap) {
+  let count = 0;
+
+  for (const prop of visibleProps) {
+    if (prop.label !== label) {
+      continue;
+    }
+
+    count++;
+
+    // First occurrence has no suffix, second is (2), third is (3), etc.
+    if (count === n) {
+      return prop;
+    }
+  }
+
+  return null;
+}

--- a/test/cliSpec.js
+++ b/test/cliSpec.js
@@ -14,8 +14,8 @@ const execFile = promisify(childProcess.execFile);
 
 describe('cli', function() {
 
-  test.only = function(testName, element) {
-    return test(testName, element, true);
+  test.only = function(testName, templateName, element) {
+    return test(testName, templateName, element, true);
   };
 
   describe('apply template', function() {
@@ -36,6 +36,423 @@ describe('cli', function() {
 
 
     test('ad-hoc', 'ad-hoc', 'AdHocSubProcess');
+  });
+
+
+  describe('apply template (with subcommand)', function() {
+
+    it('should work with explicit apply subcommand', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+      const expected = await fs.readFile(
+        'test/fixtures/diagrams/rest-conditional_expected.bpmn', 'utf8'
+      );
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'apply',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      // then
+      expect(withoutDiagram(stdout.trim())).to.eql(withoutDiagram(expected.trim()));
+    });
+  });
+
+
+  describe('query fields', function() {
+
+    it('should return visible fields with default values (no groups)', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+
+      // then - should have General section
+      expect(result).to.have.property('General');
+
+      const general = result['General'];
+
+      // Visible: REST Endpoint URL, REST Method, Authentication Type
+      expect(general).to.have.property('REST Endpoint URL');
+      expect(general).to.have.property('REST Method');
+      expect(general).to.have.property('Authentication Type');
+
+      // Hidden: Request Body (method=get), Username, Password, Bearer Token
+      expect(general).to.not.have.property('Request Body');
+      expect(general).to.not.have.property('Username');
+      expect(general).to.not.have.property('Password');
+      expect(general).to.not.have.property('Bearer Token');
+    });
+
+
+    it('should include type and choices for Dropdown fields', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+      const method = result['General']['REST Method'];
+
+      // then
+      expect(method.type).to.eql('Dropdown');
+      expect(method.value).to.eql('get');
+      expect(method.choices).to.deep.eql([
+        { name: 'GET', value: 'get' },
+        { name: 'POST', value: 'post' },
+        { name: 'PATCH', value: 'patch' },
+        { name: 'DELETE', value: 'delete' }
+      ]);
+    });
+
+
+    it('should include constraints', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+      const url = result['General']['REST Endpoint URL'];
+
+      // then
+      expect(url.type).to.eql('String');
+      expect(url.constraints).to.deep.eql({
+        notEmpty: true,
+        pattern: {
+          value: '^https?://.*',
+          message: 'Must be http(s) URL.'
+        }
+      });
+    });
+
+
+    it('should organize fields by groups', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/easy-post-connector.bpmn';
+      const template = 'test/fixtures/templates/easy-post-connector.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+      const sections = Object.keys(result);
+
+      // then - should have known groups
+      expect(sections).to.include('Operation');
+      expect(sections).to.include('Authentication');
+      expect(sections).to.include('Error handling');
+
+      // Operation type dropdown should be in Operation group
+      expect(result['Operation']).to.have.property('Operation type');
+      expect(result['Operation']['Operation type'].type).to.eql('Dropdown');
+    });
+
+
+    it('should include feel mode when set', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/easy-post-connector.bpmn';
+      const template = 'test/fixtures/templates/easy-post-connector.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+
+      // then - API key has feel: optional
+      expect(result['Authentication']['API key'].feel).to.eql('optional');
+    });
+
+
+    it('should not include feel when not set', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+
+      // then - REST Method has no feel property
+      expect(result['General']['REST Method']).to.not.have.property('feel');
+    });
+
+
+    it('should include description when present', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram,
+        template,
+        element: 'ServiceTask'
+      });
+
+      const result = JSON.parse(stdout);
+
+      // then
+      expect(result['General']['REST Endpoint URL'].description)
+        .to.eql('Specify the url of the REST API to talk to.');
+      expect(result['General']['REST Method'].description)
+        .to.eql('Specify the HTTP method to use.');
+    });
+  });
+
+
+  describe('set fields', function() {
+
+    it('should set a simple field value', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await exec({
+        subcommand: 'set',
+        diagram,
+        template,
+        element: 'ServiceTask',
+        values: JSON.stringify({ 'REST Endpoint URL': 'https://example.com' })
+      });
+
+      // then - URL should appear in the output
+      expect(stdout).to.include('value="https://example.com"');
+    });
+
+
+    it('should set dropdown value and reveal conditional fields', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when - set method to post, which should reveal Request Body
+      const { stdout: setOutput } = await exec({
+        subcommand: 'set',
+        diagram,
+        template,
+        element: 'ServiceTask',
+        values: JSON.stringify({ 'REST Method': 'post' })
+      });
+
+      // then - method should be post in task headers
+      expect(setOutput).to.include('value="post"');
+    });
+
+
+    it('should handle cascading conditions in a single call', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when - set method + auth + credentials in one call
+      const { stdout } = await exec({
+        subcommand: 'set',
+        diagram,
+        template,
+        element: 'ServiceTask',
+        values: JSON.stringify({
+          'REST Method': 'post',
+          'Authentication Type': 'basic',
+          'Username': 'admin',
+          'Password': 'secret'
+        })
+      });
+
+      // then - all values should be in the output
+      expect(stdout).to.include('source="admin" target="authentication.username"');
+      expect(stdout).to.include('source="secret" target="authentication.password"');
+      expect(stdout).to.include('source="basic" target="authentication.type"');
+      expect(stdout).to.include('value="post"');
+    });
+
+
+    it('should reject invalid values (pattern constraint)', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when/then
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          values: JSON.stringify({ 'REST Endpoint URL': 'not-a-url' })
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Validation failed');
+        expect(err.stderr).to.include('Must be http(s) URL');
+      }
+    });
+
+
+    it('should error on unknown field labels', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when/then
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          values: JSON.stringify({ 'Nonexistent Field': 'value' })
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Could not resolve fields');
+        expect(err.stderr).to.include('Nonexistent Field');
+      }
+    });
+
+
+    it('should error on fields hidden by conditions', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when/then - Username requires method=post + auth=basic, but we don't set those
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          values: JSON.stringify({ 'Username': 'admin' })
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Could not resolve fields');
+        expect(err.stderr).to.include('Username');
+      }
+    });
+
+
+    it('should support Section.Label format for disambiguation', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/easy-post-connector.bpmn';
+      const template = 'test/fixtures/templates/easy-post-connector.json';
+
+      // when - use "Error handling.Connection timeout" qualified format
+      const { stdout } = await exec({
+        subcommand: 'set',
+        diagram,
+        template,
+        element: 'ServiceTask',
+        values: JSON.stringify({ 'Error handling.Connection timeout': '30' })
+      });
+
+      // then
+      expect(stdout).to.include('30');
+    });
+
+
+    it('should error on invalid JSON in --values', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when/then
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          values: 'not-json'
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Invalid JSON');
+      }
+    });
+
+
+    it('should error on non-existent element ID', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when/then
+      try {
+        await exec({
+          subcommand: 'query',
+          diagram,
+          template,
+          element: 'NonexistentElement'
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('not found in diagram');
+      }
+    });
   });
 });
 
@@ -61,21 +478,12 @@ function test(testName, templateName = testName, element = 'ServiceTask', only =
   });
 }
 
-function exec(argsMap) {
-  const args = prepareArgs(argsMap);
-
-  return execFile(CLI_PATH, args, {
-    cwd: path.resolve(__dirname, '..')
-  });
-}
-
-function prepareArgs({
-  diagram,
-  template,
-  element,
-  output
-}) {
+function exec({ subcommand, diagram, template, element, output, values } = {}) {
   const args = [];
+
+  if (subcommand) {
+    args.push(subcommand);
+  }
 
   if (diagram) {
     args.push('--diagram', diagram);
@@ -93,7 +501,13 @@ function prepareArgs({
     args.push('--output', output);
   }
 
-  return args;
+  if (values) {
+    args.push('--values', values);
+  }
+
+  return execFile(CLI_PATH, args, {
+    cwd: path.resolve(__dirname, '..')
+  });
 }
 
 /**

--- a/test/cliSpec.js
+++ b/test/cliSpec.js
@@ -1,6 +1,7 @@
 import { promisify } from 'node:util';
 import childProcess from 'node:child_process';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { expect } from 'chai';
 
@@ -454,7 +455,242 @@ describe('cli', function() {
       }
     });
   });
+
+
+  describe('template resolution', function() {
+
+    const fixtureDiagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+    const fixtureTemplate = 'test/fixtures/templates/rest-conditional.json';
+
+    it('should resolve via --template-path', async function() {
+
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram: fixtureDiagram,
+        templatePath: fixtureTemplate,
+        element: 'ServiceTask'
+      });
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed).to.be.an('object');
+    });
+
+
+    it('should accept --template as deprecated alias', async function() {
+
+      // covered implicitly by other tests, but assert explicitly here
+      const { stdout } = await exec({
+        subcommand: 'query',
+        diagram: fixtureDiagram,
+        template: fixtureTemplate,
+        element: 'ServiceTask'
+      });
+
+      expect(JSON.parse(stdout)).to.be.an('object');
+    });
+
+
+    it('should error when no template source is given', async function() {
+
+      try {
+        await exec({
+          subcommand: 'query',
+          diagram: fixtureDiagram,
+          element: 'ServiceTask'
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Missing template source');
+      }
+    });
+
+
+    it('should error when both --template-path and --template-id are given', async function() {
+
+      try {
+        await exec({
+          subcommand: 'query',
+          diagram: fixtureDiagram,
+          templatePath: fixtureTemplate,
+          templateId: 'io.camunda.connectors.HttpJson.v2',
+          element: 'ServiceTask'
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Use only one of');
+      }
+    });
+
+
+    it('should resolve --template-id from walked-up .camunda/ dir', async function() {
+
+      // given: copy fixture into a temp .camunda/element-templates/ dir
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'et-cli-'));
+      const localTemplatesDir = path.join(tmpRoot, 'project', '.camunda', 'element-templates');
+      await fs.mkdir(localTemplatesDir, { recursive: true });
+
+      const templateContent = await fs.readFile(fixtureTemplate, 'utf8');
+      const template = JSON.parse(templateContent);
+      template.id = 'io.test.cli.resolve-local';
+      await fs.writeFile(
+        path.join(localTemplatesDir, 'local.json'),
+        JSON.stringify(template)
+      );
+
+      // copy the diagram into the project dir so walk-up finds the .camunda/ dir
+      const diagramContent = await fs.readFile(fixtureDiagram, 'utf8');
+      const localDiagram = path.join(tmpRoot, 'project', 'diagram.bpmn');
+      await fs.writeFile(localDiagram, diagramContent);
+
+      try {
+        const { stdout } = await exec({
+          subcommand: 'query',
+          diagram: localDiagram,
+          templateId: 'io.test.cli.resolve-local',
+          element: 'ServiceTask',
+
+          // isolate from any local cache / modeler install
+          env: {
+            XDG_CACHE_HOME: path.join(tmpRoot, 'cache'),
+            XDG_CONFIG_HOME: path.join(tmpRoot, 'config')
+          }
+        });
+
+        expect(JSON.parse(stdout)).to.be.an('object');
+      } finally {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
+
+    it('should error when --template-id is unresolvable', async function() {
+
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'et-cli-'));
+
+      try {
+        await exec({
+          subcommand: 'query',
+          diagram: fixtureDiagram,
+          templateId: 'io.test.cli.definitely-does-not-exist-abc123',
+          element: 'ServiceTask',
+          env: {
+            XDG_CACHE_HOME: path.join(tmpRoot, 'cache'),
+            XDG_CONFIG_HOME: path.join(tmpRoot, 'config')
+          }
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.match(/not found in local paths|marketplace/);
+      } finally {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+
+  describe('list templates', function() {
+
+    it('should list distinct template ids from local dirs', async function() {
+
+      // given
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'etc-list-'));
+
+      // getCliCacheDir() returns XDG_CACHE_HOME/element-templates-cli
+      const templateDir = path.join(tmpRoot, 'element-templates-cli', 'templates');
+      await fs.mkdir(templateDir, { recursive: true });
+
+      // Write two templates with different ids
+      await fs.writeFile(path.join(templateDir, 'a.json'), JSON.stringify({ id: 'com.example.A', name: 'Template A', version: 1 }));
+      await fs.writeFile(path.join(templateDir, 'b.json'), JSON.stringify([
+        { id: 'com.example.B', name: 'Template B', version: 1 },
+        { id: 'com.example.B', name: 'Template B', version: 2 }
+      ]));
+
+      // when
+      const { stdout } = await execRaw([ 'list' ], {
+        env: {
+          XDG_CACHE_HOME: tmpRoot,
+          XDG_CONFIG_HOME: path.join(tmpRoot, 'empty-config')
+        }
+      });
+
+      // then
+      expect(stdout).to.include('com.example.A');
+      expect(stdout).to.include('com.example.B');
+
+      // de-duplicated: B appears only once
+      const lines = stdout.trim().split('\n').filter(l => l.includes('com.example.B'));
+      expect(lines).to.have.length(1);
+
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    });
+
+
+    it('should list all versions for a specific --id', async function() {
+
+      // given
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'etc-list-'));
+      const templateDir = path.join(tmpRoot, 'element-templates-cli', 'templates');
+      await fs.mkdir(templateDir, { recursive: true });
+
+      await fs.writeFile(path.join(templateDir, 'b.json'), JSON.stringify([
+        { id: 'com.example.B', name: 'Template B', version: 1 },
+        { id: 'com.example.B', name: 'Template B', version: 2 }
+      ]));
+
+      // when
+      const { stdout } = await execRaw([ 'list', '--id', 'com.example.B' ], {
+        env: {
+          XDG_CACHE_HOME: tmpRoot,
+          XDG_CONFIG_HOME: path.join(tmpRoot, 'empty-config')
+        }
+      });
+
+      // then
+      expect(stdout).to.include('v1');
+      expect(stdout).to.include('v2');
+
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    });
+
+
+    it('should error when --id has no matches', async function() {
+
+      // given
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'etc-list-'));
+      await fs.mkdir(path.join(tmpRoot, 'templates'), { recursive: true });
+
+      try {
+        await execRaw([ 'list', '--id', 'does.not.exist' ], {
+          env: {
+            XDG_CACHE_HOME: tmpRoot,
+            XDG_CONFIG_HOME: path.join(tmpRoot, 'empty-config')
+          }
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('does.not.exist');
+      } finally {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+
+  describe('download templates', function() {
+
+    it('should error when --id is missing', async function() {
+
+      try {
+        await execRaw([ 'download' ]);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('--id');
+      }
+    });
+  });
 });
+
 
 function test(testName, templateName = testName, element = 'ServiceTask', only = false) {
   const fn = only ? it.only : it;
@@ -478,7 +714,10 @@ function test(testName, templateName = testName, element = 'ServiceTask', only =
   });
 }
 
-function exec({ subcommand, diagram, template, element, output, values } = {}) {
+function exec({
+  subcommand, diagram, template, templatePath, templateId,
+  element, output, values, cwd, env
+} = {}) {
   const args = [];
 
   if (subcommand) {
@@ -491,6 +730,14 @@ function exec({ subcommand, diagram, template, element, output, values } = {}) {
 
   if (template) {
     args.push('--template', template);
+  }
+
+  if (templatePath) {
+    args.push('--template-path', templatePath);
+  }
+
+  if (templateId) {
+    args.push('--template-id', templateId);
   }
 
   if (element) {
@@ -506,7 +753,15 @@ function exec({ subcommand, diagram, template, element, output, values } = {}) {
   }
 
   return execFile(CLI_PATH, args, {
-    cwd: path.resolve(__dirname, '..')
+    cwd: cwd ?? path.resolve(__dirname, '..'),
+    env: { ...process.env, ...env }
+  });
+}
+
+function execRaw(args, { cwd, env } = {}) {
+  return execFile(CLI_PATH, args, {
+    cwd: cwd ?? path.resolve(__dirname, '..'),
+    env: { ...process.env, ...env }
   });
 }
 

--- a/test/cliSpec.js
+++ b/test/cliSpec.js
@@ -454,6 +454,190 @@ describe('cli', function() {
         expect(err.stderr).to.include('not found in diagram');
       }
     });
+
+
+    it('should read values from --values-file', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      const tmpFile = path.join(os.tmpdir(), `etc-values-${Date.now()}.json`);
+      await fs.writeFile(tmpFile, JSON.stringify({
+        'REST Endpoint URL': 'https://from-file.example.com'
+      }));
+
+      try {
+
+        // when
+        const { stdout } = await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          valuesFile: tmpFile
+        });
+
+        // then
+        expect(stdout).to.include('value="https://from-file.example.com"');
+      } finally {
+        await fs.rm(tmpFile, { force: true });
+      }
+    });
+
+
+    it('should read --values from stdin when given "-"', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await execWithStdin(
+        [
+          'set',
+          '--diagram', diagram,
+          '--template', template,
+          '--element', 'ServiceTask',
+          '--values', '-'
+        ],
+        JSON.stringify({ 'REST Endpoint URL': 'https://from-stdin.example.com' })
+      );
+
+      // then
+      expect(stdout).to.include('value="https://from-stdin.example.com"');
+    });
+
+
+    it('should set a single field via --target / --value', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await execRaw([
+        'set',
+        '--diagram', diagram,
+        '--template', template,
+        '--element', 'ServiceTask',
+        '--target', 'REST Endpoint URL',
+        '--value', 'https://from-target.example.com'
+      ]);
+
+      // then
+      expect(stdout).to.include('value="https://from-target.example.com"');
+    });
+
+
+    it('should accept short -t / -v aliases', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      // when
+      const { stdout } = await execRaw([
+        'set',
+        '--diagram', diagram,
+        '--template', template,
+        '--element', 'ServiceTask',
+        '-t', 'REST Endpoint URL',
+        '-v', 'https://short.example.com'
+      ]);
+
+      // then
+      expect(stdout).to.include('value="https://short.example.com"');
+    });
+
+
+    it('should error if --target is given without --value', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      try {
+        await execRaw([
+          'set',
+          '--diagram', diagram,
+          '--template', template,
+          '--element', 'ServiceTask',
+          '--target', 'REST Method'
+        ]);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('--target and --value must be used together');
+      }
+    });
+
+
+    it('should error if --value is given without --target', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      try {
+        await execRaw([
+          'set',
+          '--diagram', diagram,
+          '--template', template,
+          '--element', 'ServiceTask',
+          '--value', 'post'
+        ]);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('--target and --value must be used together');
+      }
+    });
+
+
+    it('should error if no value source is given', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask'
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Missing field values');
+      }
+    });
+
+
+    it('should error if more than one value source is given', async function() {
+
+      // given
+      const diagram = 'test/fixtures/diagrams/rest-conditional.bpmn';
+      const template = 'test/fixtures/templates/rest-conditional.json';
+
+      const tmpFile = path.join(os.tmpdir(), `etc-values-conflict-${Date.now()}.json`);
+      await fs.writeFile(tmpFile, JSON.stringify({ 'REST Method': 'post' }));
+
+      try {
+        await exec({
+          subcommand: 'set',
+          diagram,
+          template,
+          element: 'ServiceTask',
+          values: JSON.stringify({ 'REST Method': 'get' }),
+          valuesFile: tmpFile
+        });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.stderr).to.include('Use only one of');
+      } finally {
+        await fs.rm(tmpFile, { force: true });
+      }
+    });
   });
 
 
@@ -716,7 +900,7 @@ function test(testName, templateName = testName, element = 'ServiceTask', only =
 
 function exec({
   subcommand, diagram, template, templatePath, templateId,
-  element, output, values, cwd, env
+  element, output, values, valuesFile, cwd, env
 } = {}) {
   const args = [];
 
@@ -752,6 +936,10 @@ function exec({
     args.push('--values', values);
   }
 
+  if (valuesFile) {
+    args.push('--values-file', valuesFile);
+  }
+
   return execFile(CLI_PATH, args, {
     cwd: cwd ?? path.resolve(__dirname, '..'),
     env: { ...process.env, ...env }
@@ -762,6 +950,24 @@ function execRaw(args, { cwd, env } = {}) {
   return execFile(CLI_PATH, args, {
     cwd: cwd ?? path.resolve(__dirname, '..'),
     env: { ...process.env, ...env }
+  });
+}
+
+function execWithStdin(args, input, { cwd, env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = childProcess.execFile(CLI_PATH, args, {
+      cwd: cwd ?? path.resolve(__dirname, '..'),
+      env: { ...process.env, ...env }
+    }, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        return reject(err);
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.write(input);
+    child.stdin.end();
   });
 }
 

--- a/test/downloadTemplateSpec.js
+++ b/test/downloadTemplateSpec.js
@@ -1,0 +1,155 @@
+import { expect } from 'chai';
+import http from 'node:http';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { downloadTemplate } from '../src/downloadTemplate.js';
+
+describe('downloadTemplate', function() {
+
+  it('should download the latest version when no version specified', async function() {
+
+    // given
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'etc-dl-'));
+    const templateV2 = { id: 'com.example.Conn', name: 'My Connector', version: 2 };
+    const templateV1 = { id: 'com.example.Conn', name: 'My Connector', version: 1 };
+
+    const routes = {};
+    const { url, close } = await serveJson(routes);
+    routes['/index.json'] = {
+      'com.example.Conn': [
+        { version: 2, ref: `${url}/template-v2.json`, engine: {} },
+        { version: 1, ref: `${url}/template-v1.json`, engine: {} }
+      ]
+    };
+    routes['/template-v2.json'] = templateV2;
+    routes['/template-v1.json'] = templateV1;
+
+    try {
+
+      // when
+      const result = await downloadTemplate('com.example.Conn', {
+        cacheDir: tmpRoot,
+        marketplaceUrl: `${url}/index.json`
+      });
+
+      // then
+      expect(result.id).to.eql('com.example.Conn');
+      expect(result.version).to.eql(2);
+      const written = JSON.parse(await fs.readFile(result.file, 'utf8'));
+      expect(written).to.deep.equal(templateV2);
+    } finally {
+      await close();
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+
+  it('should download a specific version', async function() {
+
+    // given
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'etc-dl-'));
+    const templateV1 = { id: 'com.example.Conn', name: 'My Connector', version: 1 };
+
+    const routes = {};
+    const { url, close } = await serveJson(routes);
+    routes['/index.json'] = {
+      'com.example.Conn': [
+        { version: 2, ref: `${url}/template-v2.json`, engine: {} },
+        { version: 1, ref: `${url}/template-v1.json`, engine: {} }
+      ]
+    };
+    routes['/template-v2.json'] = { id: 'com.example.Conn', version: 2 };
+    routes['/template-v1.json'] = templateV1;
+
+    try {
+
+      // when
+      const result = await downloadTemplate('com.example.Conn', {
+        version: 1,
+        cacheDir: tmpRoot,
+        marketplaceUrl: `${url}/index.json`
+      });
+
+      // then
+      expect(result.version).to.eql(1);
+      const written = JSON.parse(await fs.readFile(result.file, 'utf8'));
+      expect(written).to.deep.equal(templateV1);
+    } finally {
+      await close();
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+
+  it('should throw when id is not in the index', async function() {
+
+    // given
+    const routes = {};
+    const { url, close } = await serveJson(routes);
+    routes['/index.json'] = { 'com.example.Other': [] };
+
+    try {
+      await downloadTemplate('com.example.Missing', {
+        marketplaceUrl: `${url}/index.json`
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.message).to.include('com.example.Missing');
+    } finally {
+      await close();
+    }
+  });
+
+
+  it('should throw when requested version is not available', async function() {
+
+    // given
+    const routes = {};
+    const { url, close } = await serveJson(routes);
+    routes['/index.json'] = {
+      'com.example.Conn': [
+        { version: 2, ref: `${url}/template-v2.json`, engine: {} }
+      ]
+    };
+
+    try {
+      await downloadTemplate('com.example.Conn', {
+        version: 99,
+        marketplaceUrl: `${url}/index.json`
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.message).to.include('99');
+      expect(err.message).to.include('Available');
+    } finally {
+      await close();
+    }
+  });
+});
+
+
+function serveJson(routes) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const body = routes[req.url];
+      if (body === undefined) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const url = `http://127.0.0.1:${port}`;
+      const close = () => new Promise((res, rej) => server.close(err => err ? rej(err) : res()));
+      resolve({ url, close });
+    });
+
+    server.on('error', reject);
+  });
+}


### PR DESCRIPTION
## Summary

Adds two new CLI subcommands (`query` and `set`) plus explicit template-resolution flags that enable programmatic querying and configuration of BPMN element template fields — designed for agentic/AI workflows to interact with element templates the same way a human would in the Camunda Modeler.

- **`query`**: Returns visible fields as JSON organized by groups/sections, including `type`, `value`, `choices` (Dropdown), `feel` mode, `constraints`, and `description`. Hidden properties are excluded; ungrouped properties go under `"General"`.
- **`set`**: Sets field values via `--values '{"Label": "value"}'` using labels as keys, with `"Section.Label"` fallback for disambiguation. Supports cascading condition re-evaluation so newly-visible fields can be set in the same invocation. Enforces constraints (notEmpty, pattern, minLength, maxLength) before applying.

Backward compatible: omitting a subcommand defaults to `apply`; the old `--template` flag still works as a deprecated alias for `--template-path`.

## Template resolution

Replaces the single `--template <path>` flag with two explicit flags:

- `--template-path` / `--tp` — path to an element template JSON file
- `--template-id` / `--ti` — template ID (e.g. `io.camunda.connectors.HttpJson.v2`)

ID resolution follows [Desktop Modeler's lookup order](https://docs.camunda.io/docs/components/modeler/desktop-modeler/search-paths/):
1. Walked-up `.camunda/element-templates/` directories (relative to the diagram)
2. Desktop Modeler's user data dir (`~/.config/camunda-modeler/`, `~/Library/Application Support/camunda-modeler/`, or `%APPDATA%\Roaming\camunda-modeler\`)
3. CLI's own XDG cache (`~/.cache/element-templates-cli/`)

On cache miss, fetches from the [Camunda marketplace index](https://marketplace.cloud.camunda.io/api/v1/ootb-connectors), picks the latest version of the given ID, downloads the `ref`, and caches it. Matches the behavior of `camunda-modeler/app/lib/template-updater`.

## CLI help

All subcommands expose `--help` / `-h`. The root command lists subcommands; each subcommand describes its options, required flags, and the `--values` JSON format for `set`.

Considered switching to a third-party CLI parser for auto-generated help. Two bpmn-io precedents exist: `meow` (`bpmn-to-image`) and `mri` (`bpmnlint`). Kept `node:util` `parseArgs` to maintain zero runtime dependencies — the manual help strings are a one-time cost.

## Changes

### New files
- `src/queryFields.js` — query implementation with conditions, groups, metadata
- `src/setFields.js` — set implementation with validation, cascading, section-qualified labels, duplicate-label `(N)` suffix support
- `src/modeler.js` — shared modeler setup extracted from `applyTemplate.js`
- `src/resolveTemplate.js` — Desktop-Modeler-compatible template lookup + marketplace fetch + XDG cache

### Modified files
- `bin/cli.js` — subcommand routing (`apply`/`query`/`set`), `--help`, `--template-path` / `--template-id` flags, global error handler
- `src/applyTemplate.js` — refactored to use shared `modeler.js`
- `src/index.js` — exports `queryFields`, `setFields`, `resolveTemplatePath`, `resolveTemplateId`
- `package.json` — dependency on fork of `bpmn-js-element-templates`; esbuild now bundles with `--platform=node` so node built-ins work
- `test/cliSpec.js` — 29 tests (apply + query + set + template resolution)

## Upstream dependency

This requires `bpmn-js-element-templates` to export utility functions (`getPropertyValue`, `setPropertyValue`, `validateProperty`, `applyConditions`, `isConditionMet`) via a `./util` entry point. These are already `export function` in source but not re-exported from package entry points.

- Upstream PR: https://github.com/bpmn-io/bpmn-js-element-templates/pull/236
- Upstream issue: https://github.com/bpmn-io/bpmn-js-element-templates/issues/235
- Feature spec: https://github.com/bpmn-io/element-templates-cli/issues/43

Currently depends on `vringar/bpmn-js-element-templates#feat/export-util-subpath` (the fork branch behind the upstream PR) so the package is buildable without a local checkout.

## Test plan

All 29 tests pass:
- Apply: 6 fixture-based + 1 explicit subcommand
- Query: visible fields, types, choices, constraints, feel, description, groups
- Set: simple values, cascading conditions, Section.Label disambiguation, validation errors, unknown labels, hidden fields, invalid JSON, missing element ID
- Template resolution: --template-path, deprecated --template, missing source error, mutual-exclusion error, walked-up .camunda/ dir, unresolvable ID error

Closes #43